### PR TITLE
[Feat] useScrollTransition 커스텀 훅 추가

### DIFF
--- a/src/common/throttleRaf.js
+++ b/src/common/throttleRaf.js
@@ -1,0 +1,24 @@
+/**
+ * request animation frame에 따라 스로틀링을 적용하는 고차 함수입니다.
+ * 스로틀링을 적용시킬 함수를 인자로 넣으면, 스로틀이 적용된 함수를 반환합니다.
+ * 스로틀링이 적용된 함수는 원본 함수와 동일한 매개변수를 받습니다.
+ * 
+ * 주로 스크롤 애니메이션이나 마우스 드래그 애니메이션 시, 스로틀링을 걸어 함수의 실행 빈도를 줄여 성능을 향상시키는 용도로 사용합니다.
+ */
+function throttleRaf(func)
+{
+	let throttleArgs = [];
+	let isDelayed = false;
+	return function(...args)
+	{
+		throttleArgs = args;
+		if(isDelayed) return;
+		isDelayed = true;
+		requestAnimationFrame( ()=>{
+			func(...throttleArgs);
+			isDelayed = false;
+		} );
+	}
+}
+
+export default throttleRaf;

--- a/src/common/throttleRaf.js
+++ b/src/common/throttleRaf.js
@@ -2,23 +2,21 @@
  * request animation frame에 따라 스로틀링을 적용하는 고차 함수입니다.
  * 스로틀링을 적용시킬 함수를 인자로 넣으면, 스로틀이 적용된 함수를 반환합니다.
  * 스로틀링이 적용된 함수는 원본 함수와 동일한 매개변수를 받습니다.
- * 
+ *
  * 주로 스크롤 애니메이션이나 마우스 드래그 애니메이션 시, 스로틀링을 걸어 함수의 실행 빈도를 줄여 성능을 향상시키는 용도로 사용합니다.
  */
-function throttleRaf(func)
-{
-	let throttleArgs = [];
-	let isDelayed = false;
-	return function(...args)
-	{
-		throttleArgs = args;
-		if(isDelayed) return;
-		isDelayed = true;
-		requestAnimationFrame( ()=>{
-			func(...throttleArgs);
-			isDelayed = false;
-		} );
-	}
+function throttleRaf(func) {
+  let throttleArgs = [];
+  let isDelayed = false;
+  return function (...args) {
+    throttleArgs = args;
+    if (isDelayed) return;
+    isDelayed = true;
+    requestAnimationFrame(() => {
+      func(...throttleArgs);
+      isDelayed = false;
+    });
+  };
 }
 
 export default throttleRaf;

--- a/src/common/useScrollTransition.js
+++ b/src/common/useScrollTransition.js
@@ -1,12 +1,6 @@
 import { useState, useEffect } from "react";
 import throttleRaF from "./throttleRaf.js";
-
-function clamp(target, min, max)
-{
-	if(target < min) return min;
-	if(target > max) return max;
-	return target;
-}
+import { clamp } from "./utils.js";
 
 /**
  * 스크롤 트랜지션을 더 쉽게 사용할 수 있게 하는 커스텀 훅입니다.

--- a/src/common/useScrollTransition.js
+++ b/src/common/useScrollTransition.js
@@ -1,29 +1,30 @@
 import { useState, useEffect } from "react";
-import throttleRaF from "./throttleRaf.js";
+import throttleRaf from "./throttleRaf.js";
 import { clamp } from "./utils.js";
 
 /**
  * 스크롤 트랜지션을 더 쉽게 사용할 수 있게 하는 커스텀 훅입니다.
- * 
- * @param {number} start - 스크롤이 시작되는 위치입니다.
- * @param {number} end - 스크롤이 종료되는 위치입니다.
- * 
- * @return {number} 시작 위치와 종료 위치에 따른 현재 스크롤 위치의 진행 비율입니다.
+ *
+ * @param {number} scrollStart - 스크롤이 시작되는 위치입니다.
+ * @param {number} scrollEnd - 스크롤이 종료되는 위치입니다.
+ * @param {number} valueStart - 값의 시작 지점입니다.
+ * @param {number} valueEnd - 값의 종료 지점입니다.
+ *
+ * @return {number} 실제로 변환된 값입니다.
  */
-function useScrollTransition(start, end, transFunc)
-{
-	const [scroll, setScroll] = useState(0);
+function useScrollTransition({ scrollStart, scrollEnd, valueStart, valueEnd }) {
+  const [scroll, setScroll] = useState(0);
 
-	useEffect( ()=>{
-		const scrollRenew = throttleRaf( ()=>setScroll(window.scrollY) );
-		document.addEventListener("scroll", scrollRenew);
-		()=> {
-			document.removeEventListener("scroll", scrollRenew);
-		}
-	}, [] );
+  useEffect(() => {
+    const scrollRenew = throttleRaf(() => setScroll(window.scrollY));
+    document.addEventListener("scroll", scrollRenew);
+    () => {
+      document.removeEventListener("scroll", scrollRenew);
+    };
+  }, []);
 
-	const ratio = clamp((scroll - start) / (end-start), 0, 1);
-	return ratio;
+  const ratio = clamp((scroll - scrollStart) / (scrollEnd - scrollStart), 0, 1);
+  return ratio * (valueEnd - valueStart) + valueStart;
 }
 
 export default useScrollTransition;

--- a/src/common/useScrollTransition.js
+++ b/src/common/useScrollTransition.js
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+import throttleRaF from "./throttleRaf.js";
+
+function clamp(target, min, max)
+{
+	if(target < min) return min;
+	if(target > max) return max;
+	return target;
+}
+
+/**
+ * 스크롤 트랜지션을 더 쉽게 사용할 수 있게 하는 커스텀 훅입니다.
+ * 
+ * @param {number} start - 스크롤이 시작되는 위치입니다.
+ * @param {number} end - 스크롤이 종료되는 위치입니다.
+ * 
+ * @return {number} 시작 위치와 종료 위치에 따른 현재 스크롤 위치의 진행 비율입니다.
+ */
+function useScrollTransition(start, end, transFunc)
+{
+	const [scroll, setScroll] = useState(0);
+
+	useEffect( ()=>{
+		const scrollRenew = throttleRaf( ()=>setScroll(window.scrollY) );
+		document.addEventListener("scroll", scrollRenew);
+		()=> {
+			document.removeEventListener("scroll", scrollRenew);
+		}
+	}, [] );
+
+	const ratio = clamp((scroll - start) / (end-start), 0, 1);
+	return ratio;
+}
+
+export default useScrollTransition;

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,11 +1,9 @@
-export function clamp(target, min, max)
-{
-	if(target < min) return min;
-	if(target > max) return max;
-	return target;
+export function clamp(target, min, max) {
+  if (target < min) return min;
+  if (target > max) return max;
+  return target;
 }
 
-export function linearMap(ratio, min, max)
-{
-	return ratio * (max - min) + min;
+export function linearMap(ratio, min, max) {
+  return ratio * (max - min) + min;
 }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,0 +1,11 @@
+export function clamp(target, min, max)
+{
+	if(target < min) return min;
+	if(target > max) return max;
+	return target;
+}
+
+export function linearMap(ratio, min, max)
+{
+	return ratio * (max - min) + min;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -9,7 +9,9 @@
 
 @font-face {
   font-family: "hdsans";
-  src: url("/font/HyundaiSansTextOffice-Medium.woff") format("woff"), url("/font/HyundaiSansTextOffice-Medium.ttf") format("truetype")
+  src:
+    url("/font/HyundaiSansTextOffice-Medium.woff") format("woff"),
+    url("/font/HyundaiSansTextOffice-Medium.ttf") format("truetype");
 }
 
 @layer base {

--- a/src/introSection/index.jsx
+++ b/src/introSection/index.jsx
@@ -1,0 +1,27 @@
+import useScrollTransition from "@/common/useScrollTransition.js";
+
+function IntroSection() {
+  const titleOpacity = useScrollTransition({
+    scrollStart: 0,
+    scrollEnd: 500,
+    valueStart: 1,
+    valueEnd: 0,
+  });
+
+  const titleStyle = {
+    opacity: titleOpacity,
+  };
+
+  return (
+    <div className="h-[2160px]">
+      <h1
+        className="text-8xl w-full flex items-center justify-center absolute top-[500px]"
+        style={titleStyle}
+      >
+        The new IONIQ 5
+      </h1>
+    </div>
+  );
+}
+
+export default IntroSection;


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #34

# 📝 작업 내용

> useScrollTransition 훅을 작성했습니다. 원래는 확장성을 고려해서 함수를 짠다거나 해야 하겠지만... 저희 스크롤에 따라 바뀌는 애니메이션이 리니어해서 그냥 리니어하게 처리하도록 인자 4개 받았습니다.
>
> useScrollTransition 훅에서 내부적으로 사용하는 throttleRaf 함수를 작성했습니다. 브라우저 애니메이션 주기에 따라 함수가 1번만 실행되도록 보장합니다.

## 사용방법
```jsx
import useScrollTransition from "@/common/useScrollTransition.js";

function IntroSection() {
  const titleOpacity = useScrollTransition({
    scrollStart: 0,
    scrollEnd: 500,
    valueStart: 1,
    valueEnd: 0,
  });

  const titleStyle = {
    opacity: titleOpacity,
  };

  return (
    <h1 style={titleStyle}>
      The new IONIQ 5
    </h1>
  );
}
```

> Trigger : scrollY (value : 0-> 500)
> Response : opacity (value : 100-> 0)

이 디자인 명세가 위와 같은 코드로 변경됩니다.