### PR TITLE
[refactor] 헤더바 개선

### DIFF
--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -3,7 +3,6 @@ import style from "./index.module.css";
 
 export default function Header() {
   const [scrollState, setScrollState] = useState(null);
-  const scrollListRef = useRef([]);
   const [positionList, setPositionList] = useState([]);
   const scrollSectionList = [
     "추첨 이벤트",
@@ -13,10 +12,9 @@ export default function Header() {
   ];
 
   useEffect(() => {
-    const newPositionList = scrollListRef.current.map((ref) => {
-      const pos = ref.getBoundingClientRect();
-      return pos.left + ref.offsetWidth / 2 - 25;
-    });
+    const browserHalfWidth = window.innerWidth / 2;
+    const newPositionList = [browserHalfWidth - 224, browserHalfWidth - 96, browserHalfWidth + 32, browserHalfWidth + 160];
+
     setPositionList(newPositionList);
   }, [scrollState]);
 
@@ -49,20 +47,17 @@ export default function Header() {
   }
 
   return (
-    <div className="sticky top-0 h-[60px] backdrop-blur-xl flex justify-between items-center pl-[36px] pr-[46px] font-bold select-none">
-      <span onClick={gotoTop} className="text-black text-[22px] cursor-pointer">
+    <div className="sticky top-0 h-[60px] backdrop-blur-xl flex justify-center items-center font-bold select-none">
+      <span onClick={gotoTop} className="absolute left-9 text-black text-body-l cursor-pointer">
         The new IONIQ 5
       </span>
 
-      <div className="flex h-full gap-8 text-[16px]">
+      <div className="flex h-full gap-8 text-body-m">
         {scrollSectionList.map((scrollSection, index) => (
           <div
             key={index}
-            ref={(section) => {
-              scrollListRef.current[index] = section;
-            }}
             onClick={() => onClickScrollSection(index)}
-            className={`flex items-center cursor-pointer ${scrollState === index ? "text-black" : "text-neutral-300"}`}
+            className={`flex justify-center items-center w-24 cursor-pointer border border-red-500 ${scrollState === index ? "text-black" : "text-neutral-300"}`}
           >
             {scrollSection}
           </div>
@@ -76,7 +71,7 @@ export default function Header() {
 
       <button
         onClick={openVerifyModal}
-        className="bg-blue-400 text-white text-[14px] py-[12px] px-[16px]"
+        className="absolute right-[46px] bg-blue-400 text-white text-body-s py-3 px-4"
       >
         본인인증하기
       </button>

--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import style from "./index.module.css";
 
 export default function Header() {
@@ -11,12 +11,17 @@ export default function Header() {
     "선착순 이벤트",
   ];
 
-  useEffect(() => {
+  function updatePositions() {
     const browserHalfWidth = window.innerWidth / 2;
     const newPositionList = [browserHalfWidth - 224, browserHalfWidth - 96, browserHalfWidth + 32, browserHalfWidth + 160];
-
     setPositionList(newPositionList);
-  }, [scrollState]);
+  };
+
+  useEffect(() => {
+    updatePositions();
+    window.addEventListener('resize', () => updatePositions());
+    return () => window.removeEventListener('resize', () => updatePositions());
+  }, []);
 
   function gotoTop() {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -57,7 +62,7 @@ export default function Header() {
           <div
             key={index}
             onClick={() => onClickScrollSection(index)}
-            className={`flex justify-center items-center w-24 cursor-pointer border border-red-500 ${scrollState === index ? "text-black" : "text-neutral-300"}`}
+            className={`flex justify-center items-center w-24 cursor-pointer ${scrollState === index ? "text-black" : "text-neutral-300"}`}
           >
             {scrollSection}
           </div>


### PR DESCRIPTION
# #️⃣ 연관 이슈
- #9 

# 📝 작업 내용

> ref로 섹션 DOM을 참고해 좌표값을 직접 받아오지 않고 화면의 중심으로 절대값을 계산해 검정 바의 움직이는 위치가 결정되게끔 했습니다. 덕분에 ref를 사용하지 않고 복잡한 로직을 버림과 동시에 성능상의 이점은 생겼습니다만, CSS 수치만 사용하기 때문에 매직넘버스러운 코드가 추가되었습니다...
그리고 위의 작업을 위해 명세서와 약간 다르게 디자인을 설계할 수 밖에 없었습니다. 문구가 들어있는 섹션의 너비를 96px로 고정시켰습니다. 그리고, 양 끝의 IONIQ과 본인인증 버튼은 부모의 flex에 영향을 받지 않고자 absolute로 두었습니다. 이래야지 화면의 절반을 계산해 정확한 출력이 나옵니다.
이밖에도 화면의 크기를 실시간으로 반영하여 검정 바도 움직이게끔 했습니다.


## 참고 이미지 및 자료
![제목 없음](https://github.com/user-attachments/assets/e6924e97-2050-4755-a73d-7407f6e76597)
