### PR TITLE
[refactor] 헤더바 개선

### DIFF
--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -34,12 +34,10 @@ export default function Header() {
 
   function scrollDynamicStyle() {
     if (scrollState < 0) return;
-    let newPositionList = [];
-    for (let i = 0; i < scrollSectionList.length; i++) {
-      newPositionList[i] = ITEM_WIDTH / 4 + i * (ITEM_WIDTH + ITEM_GAP);
-    }
 
-    const position = Math.floor(newPositionList[scrollState]);
+    const position = Math.floor(
+      ITEM_WIDTH / 4 + scrollState * (ITEM_WIDTH + ITEM_GAP),
+    );
     return {
       "--pos": position,
     };

--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import style from "./index.module.css";
 
 export default function Header() {
-  const [scrollState, setScrollState] = useState(null);
+  const [scrollState, setScrollState] = useState(-1);
   const [positionList, setPositionList] = useState([]);
   const scrollSectionList = [
     "추첨 이벤트",
@@ -44,7 +44,7 @@ export default function Header() {
   }
 
   function scrollDynamicStyle() {
-    if (scrollState === null) return;
+    if (scrollState < 0) return;
     const position = Math.floor(positionList[scrollState]);
     return {
       "--pos": position,

--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import style from "./index.module.css";
 
 export default function Header() {
+  const ITEM_WIDTH = 96;
+  const ITEM_GAP = 32;
   const [scrollState, setScrollState] = useState(-1);
   const [positionList, setPositionList] = useState([]);
   const scrollSectionList = [
@@ -12,15 +14,18 @@ export default function Header() {
   ];
 
   function updatePositions() {
-    const browserHalfWidth = window.innerWidth / 2;
-    const newPositionList = [browserHalfWidth - 224, browserHalfWidth - 96, browserHalfWidth + 32, browserHalfWidth + 160];
+    let newPositionList = [];
+    for (let i = 0; i < scrollSectionList.length; i++) {
+      newPositionList[i] = ITEM_WIDTH / 4 + i * (ITEM_WIDTH + ITEM_GAP);
+    }
+
     setPositionList(newPositionList);
-  };
+  }
 
   useEffect(() => {
     updatePositions();
-    window.addEventListener('resize', () => updatePositions());
-    return () => window.removeEventListener('resize', () => updatePositions());
+    window.addEventListener("resize", () => updatePositions());
+    return () => window.removeEventListener("resize", () => updatePositions());
   }, []);
 
   function gotoTop() {
@@ -53,16 +58,19 @@ export default function Header() {
 
   return (
     <div className="sticky top-0 h-[60px] backdrop-blur-xl flex justify-center items-center font-bold select-none">
-      <span onClick={gotoTop} className="absolute left-9 text-black text-body-l cursor-pointer">
+      <span
+        onClick={gotoTop}
+        className="absolute left-9 text-black text-body-l cursor-pointer"
+      >
         The new IONIQ 5
       </span>
 
-      <div className="flex h-full gap-8 text-body-m">
+      <div className={`flex h-full gap-[${ITEM_GAP}px] text-body-m relative`}>
         {scrollSectionList.map((scrollSection, index) => (
           <div
             key={index}
             onClick={() => onClickScrollSection(index)}
-            className={`flex justify-center items-center w-24 cursor-pointer ${scrollState === index ? "text-black" : "text-neutral-300"}`}
+            className={`border border-red-500 flex justify-center items-center w-[${ITEM_WIDTH}px] cursor-pointer ${scrollState === index ? "text-black" : "text-neutral-300"}`}
           >
             {scrollSection}
           </div>
@@ -70,7 +78,7 @@ export default function Header() {
 
         <div
           style={scrollDynamicStyle()}
-          className={`w-[50px] h-[3px] bg-black transition ease-in-out duration-200 absolute bottom-0 left-0 ${scrollState === null ? "hidden" : style.moveBar}`}
+          className={`w-[50px] h-[3px] bg-black transition ease-in-out duration-200 absolute bottom-0 left-0 ${scrollState < 0 ? "hidden" : style.moveBar}`}
         />
       </div>
 

--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -65,12 +65,12 @@ export default function Header() {
         The new IONIQ 5
       </span>
 
-      <div className={`flex h-full gap-[${ITEM_GAP}px] text-body-m relative`}>
+      <div className={`flex h-full gap-8 text-body-m relative`}>
         {scrollSectionList.map((scrollSection, index) => (
           <div
             key={index}
             onClick={() => onClickScrollSection(index)}
-            className={`border border-red-500 flex justify-center items-center w-[${ITEM_WIDTH}px] cursor-pointer ${scrollState === index ? "text-black" : "text-neutral-300"}`}
+            className={`flex justify-center items-center w-24 cursor-pointer ${scrollState === index ? "text-black" : "text-neutral-300"}`}
           >
             {scrollSection}
           </div>

--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -1,32 +1,16 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import style from "./index.module.css";
 
 export default function Header() {
-  const ITEM_WIDTH = 96;
-  const ITEM_GAP = 32;
+  const ITEM_WIDTH = 96; // w-24
+  const ITEM_GAP = 32; // gap-8
   const [scrollState, setScrollState] = useState(-1);
-  const [positionList, setPositionList] = useState([]);
   const scrollSectionList = [
     "추첨 이벤트",
     "차량 상세정보",
     "기대평",
     "선착순 이벤트",
   ];
-
-  function updatePositions() {
-    let newPositionList = [];
-    for (let i = 0; i < scrollSectionList.length; i++) {
-      newPositionList[i] = ITEM_WIDTH / 4 + i * (ITEM_WIDTH + ITEM_GAP);
-    }
-
-    setPositionList(newPositionList);
-  }
-
-  useEffect(() => {
-    updatePositions();
-    window.addEventListener("resize", () => updatePositions());
-    return () => window.removeEventListener("resize", () => updatePositions());
-  }, []);
 
   function gotoTop() {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -50,7 +34,12 @@ export default function Header() {
 
   function scrollDynamicStyle() {
     if (scrollState < 0) return;
-    const position = Math.floor(positionList[scrollState]);
+    let newPositionList = [];
+    for (let i = 0; i < scrollSectionList.length; i++) {
+      newPositionList[i] = ITEM_WIDTH / 4 + i * (ITEM_WIDTH + ITEM_GAP);
+    }
+
+    const position = Math.floor(newPositionList[scrollState]);
     return {
       "--pos": position,
     };


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #9 

# 📝 작업 내용

> 스크롤에 따라 움직이는 바를 화면 전체 너비가 아닌 부모 래퍼 엘리먼트를 기준으로 계산합니다. 따라서 innerWidth는 더 이상 사용하지 않고, 위치를 동적으로 계산하지도 않으므로 좌표를 저장하는 상태인 positionList도 더 이상 사용하지 않습니다.
스크롤 아이템 너비를 ```ITEM_WIDTH```, 아이템 사이 간격을 ```ITEM_GAP```이라는 상수로 정의했습니다. 현재 각각 96, 32 픽셀로 정의되어 있습니다.
초기 스크롤 상태를 null이 아닌 -1로 정의했습니다.
