### PR TITLE
[feat] 모달 인터페이스 구현 ( resolve #55 )

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import IntroSection from "./introSection";
 import Header from "./header";
 import QnA from "./qna";
 import Footer from "./footer";
+import Modal from "./modal/modal.jsx";
 
 function App() {
   useEffect(() => {
@@ -21,6 +22,8 @@ function App() {
       />
       <QnA />
       <Footer />
+      <Modal layer="alert" />
+      <Modal layer="interaction" />
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,8 +22,8 @@ function App() {
       />
       <QnA />
       <Footer />
-      <Modal layer="alert" />
       <Modal layer="interaction" />
+      <Modal layer="alert" />
     </>
   );
 }

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useEffect, useState, useRef } from "react";
+import useBodyScrollLock from "./useBodyScrollLock.js";
 import useModalStore, { closeModal } from "./store.js";
 
 export const ModalCloseContext = createContext( ()=>{ console.log("모달이 닫힙니다."); } );
@@ -6,14 +7,17 @@ export const ModalCloseContext = createContext( ()=>{ console.log("모달이 닫
 function Modal({layer}) {
 	const timeoutRef = useRef(null);
 	const child = useModalStore(layer);
+	const [opacity, setOpacity] = useState(0);
+	const { lockScroll, openScroll } = useBodyScrollLock();
 	const close = useCallback( ()=>{
 		setOpacity(0);
+		openScroll();
 		timeoutRef.current = setTimeout(()=>closeModal(layer), 150);
 	}, [layer] );
-	const [opacity, setOpacity] = useState(0);
 
 	useEffect( ()=>{
 		if(child !== null) {
+			lockScroll();
 			clearTimeout(timeoutRef.current);
 			requestAnimationFrame( ()=>setOpacity(1) );
 		}

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -12,7 +12,7 @@ function Modal({layer}) {
 	const close = useCallback( ()=>{
 		setOpacity(0);
 		openScroll();
-		if(timeoutRef.current !== null) timeoutRef.current = setTimeout(()=>closeModal(layer), 150);
+		if(timeoutRef.current === null) timeoutRef.current = setTimeout(()=>closeModal(layer), 150);
 	}, [layer] );
 
 	useEffect( ()=>{

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -12,13 +12,14 @@ function Modal({layer}) {
 	const close = useCallback( ()=>{
 		setOpacity(0);
 		openScroll();
-		timeoutRef.current = setTimeout(()=>closeModal(layer), 150);
+		if(timeoutRef.current !== null) timeoutRef.current = setTimeout(()=>closeModal(layer), 150);
 	}, [layer] );
 
 	useEffect( ()=>{
 		if(child !== null) {
 			lockScroll();
 			clearTimeout(timeoutRef.current);
+			timeoutRef.current = null;
 			requestAnimationFrame( ()=>setOpacity(1) );
 		}
 	}, [child] );

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -2,42 +2,46 @@ import { createContext, useCallback, useEffect, useState, useRef } from "react";
 import useBodyScrollLock from "./useBodyScrollLock.js";
 import useModalStore, { closeModal } from "./store.js";
 
-export const ModalCloseContext = createContext( ()=>{ console.log("모달이 닫힙니다."); } );
+export const ModalCloseContext = createContext(() => {
+  console.log("모달이 닫힙니다.");
+});
 
-function Modal({layer}) {
-	const timeoutRef = useRef(null);
-	const child = useModalStore(layer);
-	const [opacity, setOpacity] = useState(0);
-	const { lockScroll, openScroll } = useBodyScrollLock();
-	const close = useCallback( ()=>{
-		setOpacity(0);
-		openScroll();
-		if(timeoutRef.current === null) timeoutRef.current = setTimeout(()=>closeModal(layer), 150);
-	}, [layer] );
+function Modal({ layer }) {
+  const timeoutRef = useRef(null);
+  const child = useModalStore(layer);
+  const [opacity, setOpacity] = useState(0);
+  const { lockScroll, openScroll } = useBodyScrollLock();
+  const close = useCallback(() => {
+    setOpacity(0);
+    openScroll();
+    if (timeoutRef.current === null)
+      timeoutRef.current = setTimeout(() => closeModal(layer), 150);
+  }, [layer, openScroll]);
 
-	useEffect( ()=>{
-		if(child !== null) {
-			lockScroll();
-			clearTimeout(timeoutRef.current);
-			timeoutRef.current = null;
-			requestAnimationFrame( ()=>setOpacity(1) );
-		}
-	}, [child] );
+  useEffect(() => {
+    if (child !== null) {
+      lockScroll();
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+      requestAnimationFrame(() => setOpacity(1));
+    }
+  }, [child, lockScroll]);
 
-	return <ModalCloseContext.Provider value={ close }>
-		{child !== null ?
-			<div className={`fixed z-[100] top-0 left-0 w-full h-dvh flex justify-center items-center transition-opacity ${opacity === 0 ? "opacity-0" : "opacity-100"}`}>
-				{child}
-				<div 
-					className="absolute w-full h-full top-0 left-0 bg-black/60 -z-10"
-					onClick={ close }
-				>
-				</div>
-			</div>
-			:
-			null
-		}
-	</ModalCloseContext.Provider>
+  return (
+    <ModalCloseContext.Provider value={close}>
+      {child !== null ? (
+        <div
+          className={`fixed z-[100] top-0 left-0 w-full h-dvh flex justify-center items-center transition-opacity ${opacity === 0 ? "opacity-0" : "opacity-100"}`}
+        >
+          {child}
+          <div
+            className="absolute w-full h-full top-0 left-0 bg-black/60 -z-10"
+            onClick={close}
+          ></div>
+        </div>
+      ) : null}
+    </ModalCloseContext.Provider>
+  );
 }
 
 export default Modal;

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -1,17 +1,27 @@
-import { createContext, useCallback } from "react";
+import { createContext, useCallback, useEffect, useState, useRef } from "react";
 import useModalStore, { closeModal } from "./store.js";
 
 export const ModalCloseContext = createContext( ()=>{ console.log("모달이 닫힙니다."); } );
 
 function Modal({layer}) {
+	const timeoutRef = useRef(null);
 	const child = useModalStore(layer);
 	const close = useCallback( ()=>{
-		closeModal(layer);
+		setOpacity(0);
+		timeoutRef.current = setTimeout(()=>closeModal(layer), 150);
 	}, [layer] );
+	const [opacity, setOpacity] = useState(0);
+
+	useEffect( ()=>{
+		if(child !== null) {
+			clearTimeout(timeoutRef.current);
+			requestAnimationFrame( ()=>setOpacity(1) );
+		}
+	}, [child] );
 
 	return <ModalCloseContext.Provider value={ close }>
 		{child !== null ?
-			<div className="fixed z-[100] top-0 left-0 w-full h-dvh flex justify-center items-center">
+			<div className={`fixed z-[100] top-0 left-0 w-full h-dvh flex justify-center items-center transition-opacity ${opacity === 0 ? "opacity-0" : "opacity-100"}`}>
 				{child}
 				<div 
 					className="absolute w-full h-full top-0 left-0 bg-black/60 -z-10"

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -1,14 +1,13 @@
-import { createContext, useCallback, useSyncExternalStore } from "react";
+import { createContext, useCallback } from "react";
 import useModalStore, { closeModal } from "./store.js";
 
 export const ModalCloseContext = createContext( ()=>{ console.log("모달이 닫힙니다."); } );
 
-function Modal({layer})
-{
+function Modal({layer}) {
 	const child = useModalStore(layer);
 	const close = useCallback( ()=>{
 		closeModal(layer);
-	}, [] );
+	}, [layer] );
 
 	return <ModalCloseContext.Provider value={ close }>
 		{child}

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -10,7 +10,18 @@ function Modal({layer}) {
 	}, [layer] );
 
 	return <ModalCloseContext.Provider value={ close }>
-		{child}
+		{child !== null ?
+			<div className="fixed z-[100] top-0 left-0 w-full h-dvh flex justify-center items-center">
+				{child}
+				<div 
+					className="absolute w-full h-full top-0 left-0 bg-black/60 -z-10"
+					onClick={ close }
+				>
+				</div>
+			</div>
+			:
+			null
+		}
 	</ModalCloseContext.Provider>
 }
 

--- a/src/modal/modal.jsx
+++ b/src/modal/modal.jsx
@@ -1,0 +1,18 @@
+import { createContext, useCallback, useSyncExternalStore } from "react";
+import useModalStore, { closeModal } from "./store.js";
+
+export const ModalCloseContext = createContext( ()=>{ console.log("모달이 닫힙니다."); } );
+
+function Modal({layer})
+{
+	const child = useModalStore(layer);
+	const close = useCallback( ()=>{
+		closeModal(layer);
+	}, [] );
+
+	return <ModalCloseContext.Provider value={ close }>
+		{child}
+	</ModalCloseContext.Provider>
+}
+
+export default Modal;

--- a/src/modal/openModal.js
+++ b/src/modal/openModal.js
@@ -1,0 +1,6 @@
+import { modalStore } from "./store.js"
+
+export default function openModal(component, layer="alert")
+{
+	modalStore.changeModal(component, layer);
+}

--- a/src/modal/openModal.js
+++ b/src/modal/openModal.js
@@ -1,5 +1,5 @@
-import { modalStore } from "./store.js"
+import { modalStore } from "./store.js";
 
-export default function openModal(component, layer="alert") {
-	modalStore.changeModal(component, layer);
+export default function openModal(component, layer = "alert") {
+  modalStore.changeModal(component, layer);
 }

--- a/src/modal/openModal.js
+++ b/src/modal/openModal.js
@@ -1,6 +1,5 @@
 import { modalStore } from "./store.js"
 
-export default function openModal(component, layer="alert")
-{
+export default function openModal(component, layer="alert") {
 	modalStore.changeModal(component, layer);
 }

--- a/src/modal/store.js
+++ b/src/modal/store.js
@@ -1,35 +1,28 @@
 import { useSyncExternalStore } from "react";
 
-class ModalStore
-{
-	constructor()
-	{
+class ModalStore {
+	constructor() {
 		this.callback = new Set();
 		this.modalChildren = new Map();
 	}
-	subscribe(callback)
-	{
+	subscribe(callback) {
 		this.callback.add( callback );
 		return ()=>this.callback.delete( callback );
 	}
-	changeModal(component, layer)
-	{
+	changeModal(component, layer) {
 		if(this.modalChildren.get(layer) === component) return;
 		this.modalChildren.set(layer, component);
 		this.#update();
 	}
-	removeModal(layer)
-	{
+	removeModal(layer) {
 		if(this.modalChildren.get(layer) === null) return;
 		this.modalChildren.set(layer, null);
 		this.#update();
 	}
-	#update()
-	{
+	#update() {
 		this.callback.forEach( (update)=>update() );
 	}
-	getSnapshot(layer)
-	{
+	getSnapshot(layer) {
 		return ()=>{
 			return this.modalChildren.get(layer) ?? null;
 		}
@@ -38,12 +31,10 @@ class ModalStore
 
 const store = new ModalStore();
 
-function useModalStore(layer)
-{
+function useModalStore(layer) {
 	return useSyncExternalStore(store.subscribe.bind(store), store.getSnapshot(layer), ()=>null);
 }
-function closeModal(layer)
-{
+function closeModal(layer) {
 	store.removeModal(layer);
 }
 

--- a/src/modal/store.js
+++ b/src/modal/store.js
@@ -1,0 +1,52 @@
+import { useSyncExternalStore } from "react";
+
+class ModalStore
+{
+	constructor()
+	{
+		this.callback = new Set();
+		this.modalChildren = new Map();
+	}
+	subscribe(callback)
+	{
+		this.callback.add( callback );
+		return ()=>this.callback.delete( callback );
+	}
+	changeModal(component, layer)
+	{
+		if(this.modalChildren.get(layer) === component) return;
+		this.modalChildren.set(layer, component);
+		this.#update();
+	}
+	removeModal(layer)
+	{
+		if(this.modalChildren.get(layer) === null) return;
+		this.modalChildren.set(layer, null);
+		this.#update();
+	}
+	#update()
+	{
+		this.callback.forEach( (update)=>update() );
+	}
+	getSnapshot(layer)
+	{
+		return ()=>{
+			return this.modalChildren.get(layer) ?? null;
+		}
+	}
+}
+
+const store = new ModalStore();
+
+function useModalStore(layer)
+{
+	return useSyncExternalStore(store.subscribe.bind(store), store.getSnapshot(layer), ()=>null);
+}
+function closeModal(layer)
+{
+	store.removeModal(layer);
+}
+
+export default useModalStore;
+
+export { store as modalStore, closeModal };

--- a/src/modal/store.js
+++ b/src/modal/store.js
@@ -1,41 +1,45 @@
 import { useSyncExternalStore } from "react";
 
 class ModalStore {
-	constructor() {
-		this.callback = new Set();
-		this.modalChildren = new Map();
-	}
-	subscribe(callback) {
-		this.callback.add( callback );
-		return ()=>this.callback.delete( callback );
-	}
-	changeModal(component, layer) {
-		if(this.modalChildren.get(layer) === component) return;
-		this.modalChildren.set(layer, component);
-		this.#update();
-	}
-	removeModal(layer) {
-		if(this.modalChildren.get(layer) === null) return;
-		this.modalChildren.set(layer, null);
-		this.#update();
-	}
-	#update() {
-		this.callback.forEach( (update)=>update() );
-	}
-	getSnapshot(layer) {
-		return ()=>{
-			return this.modalChildren.get(layer) ?? null;
-		}
-	}
+  constructor() {
+    this.callback = new Set();
+    this.modalChildren = new Map();
+  }
+  subscribe(callback) {
+    this.callback.add(callback);
+    return () => this.callback.delete(callback);
+  }
+  changeModal(component, layer) {
+    if (this.modalChildren.get(layer) === component) return;
+    this.modalChildren.set(layer, component);
+    this.#update();
+  }
+  removeModal(layer) {
+    if (this.modalChildren.get(layer) === null) return;
+    this.modalChildren.set(layer, null);
+    this.#update();
+  }
+  #update() {
+    this.callback.forEach((update) => update());
+  }
+  getSnapshot(layer) {
+    return () => {
+      return this.modalChildren.get(layer) ?? null;
+    };
+  }
 }
 
 const store = new ModalStore();
 
 function useModalStore(layer) {
-	return useSyncExternalStore(store.subscribe.bind(store), store.getSnapshot(layer), ()=>null);
+  return useSyncExternalStore(
+    store.subscribe.bind(store),
+    store.getSnapshot(layer),
+    () => null,
+  );
 }
 function closeModal(layer) {
-	store.removeModal(layer);
+  store.removeModal(layer);
 }
 
 export default useModalStore;

--- a/src/modal/useBodyScrollLock.js
+++ b/src/modal/useBodyScrollLock.js
@@ -1,25 +1,25 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from "react";
 
 //출처: https://joonfluence.tistory.com/657 [인생은 속도가 아니라 방향이다:티스토리]
 //이 코드를 작성해주신 Joonfluence님께 무한한 감사를 드립니다. 덕분에 저희의 코딩속도가 빨라졌어요
 export default function useBodyScrollLock() {
-  let scrollPosition = 0;
+  const scrollPosition = useRef(0);
   const lockScroll = useCallback(() => {
     // for IOS safari
-    scrollPosition = window.pageYOffset;
-    document.body.style.overflow = 'hidden';
-    document.body.style.position = 'fixed';
-    document.body.style.top = `-${scrollPosition}px`;
-    document.body.style.width = '100%';
+    scrollPosition.current = window.pageYOffset;
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollPosition.current}px`;
+    document.body.style.width = "100%";
   }, []);
 
   const openScroll = useCallback(() => {
     // for IOS safari
-    document.body.style.removeProperty('overflow');
-    document.body.style.removeProperty('position');
-    document.body.style.removeProperty('top');
-    document.body.style.removeProperty('width');
-    window.scrollTo(0, scrollPosition);
+    document.body.style.removeProperty("overflow");
+    document.body.style.removeProperty("position");
+    document.body.style.removeProperty("top");
+    document.body.style.removeProperty("width");
+    window.scrollTo(0, scrollPosition.current);
   }, []);
 
   return { lockScroll, openScroll };

--- a/src/modal/useBodyScrollLock.js
+++ b/src/modal/useBodyScrollLock.js
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+
+//출처: https://joonfluence.tistory.com/657 [인생은 속도가 아니라 방향이다:티스토리]
+//이 코드를 작성해주신 Joonfluence님께 무한한 감사를 드립니다. 덕분에 저희의 코딩속도가 빨라졌어요
+export default function useBodyScrollLock() {
+  let scrollPosition = 0;
+  const lockScroll = useCallback(() => {
+    // for IOS safari
+    scrollPosition = window.pageYOffset;
+    document.body.style.overflow = 'hidden';
+    document.body.style.position = 'fixed';
+    document.body.style.top = `-${scrollPosition}px`;
+    document.body.style.width = '100%';
+  }, []);
+
+  const openScroll = useCallback(() => {
+    // for IOS safari
+    document.body.style.removeProperty('overflow');
+    document.body.style.removeProperty('position');
+    document.body.style.removeProperty('top');
+    document.body.style.removeProperty('width');
+    window.scrollTo(0, scrollPosition);
+  }, []);
+
+  return { lockScroll, openScroll };
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #55 

# 📝 작업 내용

> 모달을 열 수 있는 openModal 함수를 추가했습니다.
```jsx
import openModal from "@/modal/openModal.js";

openModal(<MyComponent title="Hello, world!" />, "alert");
```
openModal 함수는 2개의 매개변수를 갖습니다. 첫 번째 매개변수로 리액트 엘리먼트를, 두 번째 매개변수로 레이어 이름을 받습니다.
레이어 이름을 안 쓰면 디폴트 레이어 이름인 "alert" 레이어에 모달이 띄워집니다.
현재 레이어는 2개로, "alert" 레이어와 "interaction" 레이어가 있습니다.

> 모달 내부 컴포넌트에서 모달을 닫을 수 있게, ModalCloseContext 인터페이스를 추가했습니다.
```jsx
const close = useContext(ModalCloseContext);
```
useContext(ModalCloseContext)의 반환값은 함수입니다. 이 함수를 호출해서 모달을 닫을 수 있습니다.

> 기본적인 모달 동작을 구현했습니다.
- 모달 밖을 클릭하면 모달이 닫히는 동작을 추가했습니다.
- 모달이 열고 닫힐 때 opacity가 변화하고, opacity가 0일 때 dom에서 제거되는 애니메이션을 주었습니다. 참고로 클릭 스패밍에 대응할 수 있습니다.

## 참고 자료
- https://react.dev/reference/react/useSyncExternalStore
- https://react.dev/reference/react/cloneElement#passing-data-through-context
- https://joonfluence.tistory.com/657
- 
## 관련 아티클
[간편하고 확장성 있는 모달 관리를 위한 노력](https://github.com/softeerbootcamp4th/Team6-AwesomeOrange-FE/wiki/%EA%B0%84%ED%8E%B8%ED%95%98%EA%B3%A0-%ED%99%95%EC%9E%A5%EC%84%B1-%EC%9E%88%EB%8A%94-%EB%AA%A8%EB%8B%AC-%EA%B4%80%EB%A6%AC%EB%A5%BC-%EC%9C%84%ED%95%9C-%EB%85%B8%EB%A0%A5)

# 💬 테스트 방법

```jsx
import { useContext } from "react";
import Modal, { ModalCloseContext } from "./modal/modal.jsx";
import openModal from "./modal/openModal.js";

function MyModal({ name }) {
  const close = useContext(ModalCloseContext);
  const secondModal = <MyModal name="hello, second!" />;

  return (
    <div className="w-72 h-48 bg-white">
      <p>안녕 난 테스트 모달: {name}이야</p>
      <div onClick={() => openModal(secondModal)}>모달2 오! 픈!</div>
      <div onClick={close}>닫아버렷!</div>
    </div>
  );
}

function App() {
  const firstModal = <MyModal name="hello, modal!" />;

  return (
    <>
      <div onClick={() => openModal(firstModal)}>모달 오! 픈!</div>
      <Modal layer="alert" />
    </>
  );
}

export default App;
```
App.jsx를 다음과 같이 일시적으로 바꿔서 시도해 보세요.