### PR TITLE
[fix] 무한 캐러셀 관련 버그 수정

### DIFF
--- a/src/comment/autoScrollCarousel/useAutoCarousel.js
+++ b/src/comment/autoScrollCarousel/useAutoCarousel.js
@@ -88,11 +88,9 @@ function useAutoCarousel(speed = 1) {
     ref: childRef,
     eventListener: {
       onMouseEnter() {
-        setIsControlled(true);
         setIsHovered(true);
       },
       onMouseLeave() {
-        setIsControlled(false);
         setIsHovered(false);
       },
       onPointerDown(e) {

--- a/src/comment/commentCarousel/index.jsx
+++ b/src/comment/commentCarousel/index.jsx
@@ -7,7 +7,7 @@ import CommentCarouselSkeleton from "./CommentCarouselSkeleton.jsx";
 import CommentCarouselError from "./CommentCarouselError.jsx";
 
 function CommentCarouselView() {
-  const resource = useMemo(()=>fetchResource("/api/v1/comment"), []);
+  const resource = useMemo(() => fetchResource("/api/v1/comment"), []);
   return (
     <ErrorBoundary fallback={<CommentCarouselError />}>
       <Suspense fallback={<CommentCarouselSkeleton />}>

--- a/src/comment/commentCarousel/index.jsx
+++ b/src/comment/commentCarousel/index.jsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import Suspense from "@/common/Suspense.jsx";
 import ErrorBoundary from "@/common/ErrorBoundary.jsx";
 import { fetchResource } from "@/common/fetchServer.js";
@@ -6,7 +7,7 @@ import CommentCarouselSkeleton from "./CommentCarouselSkeleton.jsx";
 import CommentCarouselError from "./CommentCarouselError.jsx";
 
 function CommentCarouselView() {
-  const resource = fetchResource("/api/v1/comment");
+  const resource = useMemo(()=>fetchResource("/api/v1/comment"), []);
   return (
     <ErrorBoundary fallback={<CommentCarouselError />}>
       <Suspense fallback={<CommentCarouselSkeleton />}>


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #12

# 📝 작업 내용

> 무한 캐러셀 관련 버그를 수정했습니다.
- 컴포넌트가 리렌더링될 시, 캐러셀이 아예 멈춰버리는 오류를 수정했습니다.
  - 실제로 60초마다 실행되는 로직 자체를 별도의 함수로 분리하고, requestAnimationFrame을 마운트하는 로직을 다른 useEffect를 써서 해결했습니다.
- 마우스 드래그 중인 상태에서 마우스가 캐러셀 영역을 벗어났을 때, 캐러셀이 움직이는 버그를 수정했습니다.
  - 마우스 호버/호버아웃 이벤트에서 isControlled 상태를 조절하는 걸 지웠습니다.

> 컴포넌트가 리렌더링될 시, 코멘트 섹션이 데이터를 또 불러오는 시도를 하는 오류를 수정했습니다.