### PR TITLE
[feat] 본인인증 모달 섹션 첫번째 섹션 추가 스타일 추가

### DIFF
--- a/public/icons/checked.svg
+++ b/public/icons/checked.svg
@@ -1,0 +1,5 @@
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Icon_&#236;&#178;&#180;&#237;&#129;&#172;">
+<path id="Vector 59" d="M3.33301 6.50033L6.43505 9.66699L11.333 4.66699" stroke="white"/>
+</g>
+</svg>

--- a/public/icons/close.svg
+++ b/public/icons/close.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<line x1="5.83393" y1="17.5976" x2="18.5618" y2="4.86968" stroke="#0D0D0D" stroke-width="1.5"/>
+<line x1="5.93072" y1="5.1059" x2="18.6586" y2="17.8338" stroke="#0D0D0D" stroke-width="1.5"/>
+</svg>

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -33,7 +33,7 @@ function AuthFirstSection({name, setName, phone, setPhone, goNext})
 
 	return <>
 		<p className="text-body-l font-bold text-neutral-700">이벤트 응모를 위해<br/>간단한 정보를 입력해주세요!</p>
-		<form className="flex flex-col flex-grow w-[calc(100%+0.25rem)] -left-0.5 relative pb-4 group" onSubmit={onSubmit}>
+		<form className="flex flex-col flex-grow w-[calc(100%+0.25rem)] -left-0.5 relative gap-4 pb-4 group" onSubmit={onSubmit}>
 			<div className="flex flex-col flex-grow gap-7 px-0.5 relative h-0 overflow-y-auto">
 				<div className="flex flex-col gap-6">
 					<label className="flex flex-col gap-3">

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -4,7 +4,7 @@ import PhoneInput from "@/common/PhoneInput.jsx";
 import Button from "@/common/Button.jsx";
 import { fetchServer, HTTPError } from "@/common/fetchServer.js";
 
-function AuthFirstSection({name, setName, phone, setPhone})
+function AuthFirstSection({name, setName, phone, setPhone, goNext})
 {
 	const [errorMessage, setErrorMessage] = useState("");
 
@@ -19,7 +19,7 @@ function AuthFirstSection({name, setName, phone, setPhone})
 			const body = {name, phoneNumber: phone.replace(/\D+/g, "")};
 			await fetchServer("/api/v1/event-user/send-auth", {method:"post", body});
 			setErrorMessage("");
-			console.log("성공했다!");
+			goNext();
 		} catch(e) {
 			if( e instanceof HTTPError ) {
 				if(e.status === 400) return setErrorMessage("잘못된 요청 형식입니다.");
@@ -60,7 +60,7 @@ function AuthFirstSection({name, setName, phone, setPhone})
 				</div>
 			</div>
 			<div className="w-full flex justify-center relative">
-				<Button styleType="ghost" type="submit" className="w-36 min-h-14">인증 요청하기</Button>
+				<Button styleType="filled" type="submit" className="w-36 min-h-14">인증 요청하기</Button>
 				<button type="button" className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300">이미 정보를 입력하신 적이 있으신가요?</button>
 			</div>
 		</form>

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -1,8 +1,7 @@
+import Input from "@/common/Input.jsx";
+
 function AuthFirstSection({name, setName, phone, setPhone})
 {
-	const inputboxStyle = `w-full h-14 p-4 bg-neutral-50 rounded text-body-m font-medium
-	focus:bg-white focus:outline-neutral-800
-	placeholder:text-neutral-200`;
 	const checkboxStyle = `size-4 appearance-none 
 	border border-neutral-300 checked:bg-blue-400 checked:border-0 
 	checked:bg-checked bg-center`;
@@ -14,11 +13,11 @@ function AuthFirstSection({name, setName, phone, setPhone})
 				<div className="flex flex-col gap-6">
 					<label className="flex flex-col gap-3">
 						<span className="text-body-m font-bold">이름</span>
-						<input className={inputboxStyle} type="text" placeholder="ex) 홍길동" />
+						<Input text={name} setText={setName} placeholder="ex) 홍길동" />
 					</label>
 					<label className="flex flex-col gap-3">
 						<span className="text-body-m font-bold">전화번호</span>
-						<input className={inputboxStyle} type="text" placeholder="ex) 01012345678" />
+						<Input text={phone} setText={setPhone} placeholder="ex) 01012345678" />
 						<p className="w-full h-4">{null}</p>
 					</label>
 				</div>

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -1,0 +1,46 @@
+function AuthFirstSection({name, setName, phone, setPhone})
+{
+	const inputboxStyle = `w-full h-14 p-4 bg-neutral-50 rounded text-body-m font-medium
+	focus:bg-white focus:outline-neutral-800
+	placeholder:text-neutral-200`;
+	const checkboxStyle = `size-4 appearance-none 
+	border border-neutral-300 checked:bg-blue-400 checked:border-0 
+	checked:bg-checked bg-center`;
+
+	return <>
+		<p className="text-body-l font-bold text-neutral-700">이벤트 응모를 위해<br/>간단한 정보를 입력해주세요!</p>
+		<form className="flex flex-col flex-grow w-[calc(100%+0.25rem)] -left-0.5 relative pb-4">
+			<div className="flex flex-col flex-grow px-0.5 relative h-0 overflow-y-auto">
+				<div className="flex flex-col gap-6">
+					<label className="flex flex-col gap-3">
+						<span className="text-body-m font-bold">이름</span>
+						<input className={inputboxStyle} type="text" placeholder="ex) 홍길동" />
+					</label>
+					<label className="flex flex-col gap-3">
+						<span className="text-body-m font-bold">전화번호</span>
+						<input className={inputboxStyle} type="text" placeholder="ex) 01012345678" />
+						<p className="w-full h-4">{null}</p>
+					</label>
+				</div>
+				<div className="flex flex-col gap-4 text-detail-l">	
+					<label className="flex gap-2 items-center">
+						<input type="checkbox" className={checkboxStyle}/>
+						<span className="font-bold text-neutral-600">개인정보 수집 동의(필수)</span>
+						<span className="font-medium text-neutral-300">자세히 보기</span>
+					</label>
+					<label className="flex gap-2 items-center">
+						<input type="checkbox" className={checkboxStyle}/>
+						<span className="font-bold text-neutral-600">마케팅 수신 동의(선택)</span>
+						<span className="font-medium text-neutral-300">자세히 보기</span>
+					</label>
+				</div>
+			</div>
+			<div className="w-full flex justify-center relative">
+				<button type="submit" className="w-36 min-h-14 px-6 py-4 text-center bg-black text-white">인증 요청하기</button>
+				<button type="button" className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300">이미 정보를 입력하신 적이 있으신가요?</button>
+			</div>
+		</form>
+	</>
+}
+
+export default AuthFirstSection;

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -4,67 +4,104 @@ import PhoneInput from "@/common/PhoneInput.jsx";
 import Button from "@/common/Button.jsx";
 import { fetchServer, HTTPError } from "@/common/fetchServer.js";
 
-function AuthFirstSection({name, setName, phone, setPhone, goNext})
-{
-	const [errorMessage, setErrorMessage] = useState("");
+function AuthFirstSection({ name, setName, phone, setPhone, goNext }) {
+  const [errorMessage, setErrorMessage] = useState("");
 
-	const checkboxStyle = `size-4 appearance-none 
+  const checkboxStyle = `size-4 appearance-none 
 	border border-neutral-300 checked:bg-blue-400 checked:border-0 
 	checked:bg-checked bg-center`;
 
-	async function onSubmit(e)
-	{
-		e.preventDefault();
-		try {
-			const body = {name, phoneNumber: phone.replace(/\D+/g, "")};
-			await fetchServer("/api/v1/event-user/send-auth", {method:"post", body});
-			setErrorMessage("");
-			goNext();
-		} catch(e) {
-			if( e instanceof HTTPError ) {
-				if(e.status === 400) return setErrorMessage("잘못된 요청 형식입니다.");
-				if(e.status === 409) return setErrorMessage("등록된 참여자 정보가 있습니다.");
-				return setErrorMessage("서버와의 통신 중 오류가 발생했습니다.");
-			}
-			console.error(e);
-			setErrorMessage("알 수 없는 오류입니다. 프론트엔드 개발자에게 제보하세요.");
-		}
-	}
+  async function onSubmit(e) {
+    e.preventDefault();
+    try {
+      const body = { name, phoneNumber: phone.replace(/\D+/g, "") };
+      await fetchServer("/api/v1/event-user/send-auth", {
+        method: "post",
+        body,
+      });
+      setErrorMessage("");
+      goNext();
+    } catch (e) {
+      if (e instanceof HTTPError) {
+        if (e.status === 400) return setErrorMessage("잘못된 요청 형식입니다.");
+        if (e.status === 409)
+          return setErrorMessage("등록된 참여자 정보가 있습니다.");
+        return setErrorMessage("서버와의 통신 중 오류가 발생했습니다.");
+      }
+      console.error(e);
+      setErrorMessage(
+        "알 수 없는 오류입니다. 프론트엔드 개발자에게 제보하세요.",
+      );
+    }
+  }
 
-	return <>
-		<p className="text-body-l font-bold text-neutral-700">이벤트 응모를 위해<br/>간단한 정보를 입력해주세요!</p>
-		<form className="flex flex-col flex-grow w-[calc(100%+0.25rem)] -left-0.5 relative gap-4 pb-4 group" onSubmit={onSubmit}>
-			<div className="flex flex-col flex-grow gap-7 px-0.5 relative h-0 overflow-y-auto">
-				<div className="flex flex-col gap-6">
-					<label className="flex flex-col gap-3">
-						<span className="text-body-m font-bold">이름</span>
-						<Input text={name} setText={setName} placeholder="ex) 홍길동" required minLength="2"/>
-					</label>
-					<label className="flex flex-col gap-3">
-						<span className="text-body-m font-bold">전화번호</span>
-						<PhoneInput text={phone} setText={setPhone} required isError={errorMessage !== ""}/>
-						<p className="w-full h-4 text-detail-l text-red-500">{errorMessage}</p>
-					</label>
-				</div>
-				<div className="flex flex-col gap-4 text-detail-l">	
-					<label className="flex gap-2 items-center">
-						<input type="checkbox" className={checkboxStyle} required/>
-						<span className="font-bold text-neutral-600">개인정보 수집 동의(필수)</span>
-						<span className="font-medium text-neutral-300">자세히 보기</span>
-					</label>
-					<label className="flex gap-2 items-center">
-						<input type="checkbox" className={checkboxStyle}/>
-						<span className="font-bold text-neutral-600">마케팅 수신 동의(선택)</span>
-						<span className="font-medium text-neutral-300">자세히 보기</span>
-					</label>
-				</div>
-			</div>
-			<div className="w-full flex justify-center relative">
-				<Button styleType="filled" type="submit" className="w-36 min-h-14">인증 요청하기</Button>
-				<button type="button" className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300">이미 정보를 입력하신 적이 있으신가요?</button>
-			</div>
-		</form>
-	</>
+  return (
+    <>
+      <p className="text-body-l font-bold text-neutral-700">
+        이벤트 응모를 위해
+        <br />
+        간단한 정보를 입력해주세요!
+      </p>
+      <form
+        className="flex flex-col flex-grow w-[calc(100%+0.25rem)] -left-0.5 relative gap-4 pb-4 group"
+        onSubmit={onSubmit}
+      >
+        <div className="flex flex-col flex-grow gap-7 px-0.5 relative h-0 overflow-y-auto">
+          <div className="flex flex-col gap-6">
+            <label className="flex flex-col gap-3">
+              <span className="text-body-m font-bold">이름</span>
+              <Input
+                text={name}
+                setText={setName}
+                placeholder="ex) 홍길동"
+                required
+                minLength="2"
+              />
+            </label>
+            <label className="flex flex-col gap-3">
+              <span className="text-body-m font-bold">전화번호</span>
+              <PhoneInput
+                text={phone}
+                setText={setPhone}
+                required
+                isError={errorMessage !== ""}
+              />
+              <p className="w-full h-4 text-detail-l text-red-500">
+                {errorMessage}
+              </p>
+            </label>
+          </div>
+          <div className="flex flex-col gap-4 text-detail-l">
+            <label className="flex gap-2 items-center">
+              <input type="checkbox" className={checkboxStyle} required />
+              <span className="font-bold text-neutral-600">
+                개인정보 수집 동의(필수)
+              </span>
+              <span className="font-medium text-neutral-300">자세히 보기</span>
+            </label>
+            <label className="flex gap-2 items-center">
+              <input type="checkbox" className={checkboxStyle} />
+              <span className="font-bold text-neutral-600">
+                마케팅 수신 동의(선택)
+              </span>
+              <span className="font-medium text-neutral-300">자세히 보기</span>
+            </label>
+          </div>
+        </div>
+        <div className="w-full flex justify-center relative">
+          <Button styleType="filled" type="submit" className="w-36 min-h-14">
+            인증 요청하기
+          </Button>
+          <button
+            type="button"
+            className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300"
+          >
+            이미 정보를 입력하신 적이 있으신가요?
+          </button>
+        </div>
+      </form>
+    </>
+  );
 }
 
 export default AuthFirstSection;

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -1,16 +1,39 @@
+import { useState } from "react";
 import Input from "@/common/Input.jsx";
 import PhoneInput from "@/common/PhoneInput.jsx";
+import { fetchServer, HTTPError } from "@/common/fetchServer.js";
 
 function AuthFirstSection({name, setName, phone, setPhone})
 {
+	const [errorMessage, setErrorMessage] = useState("");
+
 	const checkboxStyle = `size-4 appearance-none 
 	border border-neutral-300 checked:bg-blue-400 checked:border-0 
 	checked:bg-checked bg-center`;
 
+	async function onSubmit(e)
+	{
+		e.preventDefault();
+		try {
+			const body = {name, phoneNumber: phone.replace(/\D+/g, "")};
+			await fetchServer("/api/v1/event-user/send-auth", {method:"post", body});
+			setErrorMessage("");
+			console.log("성공했다!");
+		} catch(e) {
+			if( e instanceof HTTPError ) {
+				if(e.status === 400) return setErrorMessage("잘못된 요청 형식입니다.");
+				if(e.status === 409) return setErrorMessage("등록된 참여자 정보가 있습니다.");
+				return setErrorMessage("서버와의 통신 중 오류가 발생했습니다.");
+			}
+			console.error(e);
+			setErrorMessage("알 수 없는 오류입니다. 프론트엔드 개발자에게 제보하세요.");
+		}
+	}
+
 	return <>
 		<p className="text-body-l font-bold text-neutral-700">이벤트 응모를 위해<br/>간단한 정보를 입력해주세요!</p>
-		<form className="flex flex-col flex-grow w-[calc(100%+0.25rem)] -left-0.5 relative pb-4">
-			<div className="flex flex-col flex-grow px-0.5 relative h-0 overflow-y-auto">
+		<form className="flex flex-col flex-grow w-[calc(100%+0.25rem)] -left-0.5 relative pb-4 group" onSubmit={onSubmit}>
+			<div className="flex flex-col flex-grow gap-7 px-0.5 relative h-0 overflow-y-auto">
 				<div className="flex flex-col gap-6">
 					<label className="flex flex-col gap-3">
 						<span className="text-body-m font-bold">이름</span>
@@ -18,13 +41,13 @@ function AuthFirstSection({name, setName, phone, setPhone})
 					</label>
 					<label className="flex flex-col gap-3">
 						<span className="text-body-m font-bold">전화번호</span>
-						<PhoneInput text={phone} setText={setPhone} required/>
-						<p className="w-full h-4">{null}</p>
+						<PhoneInput text={phone} setText={setPhone} required isError={errorMessage !== ""}/>
+						<p className="w-full h-4 text-detail-l text-red-500">{errorMessage}</p>
 					</label>
 				</div>
 				<div className="flex flex-col gap-4 text-detail-l">	
 					<label className="flex gap-2 items-center">
-						<input type="checkbox" className={checkboxStyle}/>
+						<input type="checkbox" className={checkboxStyle} required/>
 						<span className="font-bold text-neutral-600">개인정보 수집 동의(필수)</span>
 						<span className="font-medium text-neutral-300">자세히 보기</span>
 					</label>
@@ -36,7 +59,7 @@ function AuthFirstSection({name, setName, phone, setPhone})
 				</div>
 			</div>
 			<div className="w-full flex justify-center relative">
-				<button type="submit" className="w-36 min-h-14 px-6 py-4 text-center bg-black text-white">인증 요청하기</button>
+				<button type="submit" className="w-36 min-h-14 px-6 py-4 text-center bg-black text-white group-[:invalid]:bg-neutral-500">인증 요청하기</button>
 				<button type="button" className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300">이미 정보를 입력하신 적이 있으신가요?</button>
 			</div>
 		</form>

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import Input from "@/common/Input.jsx";
 import PhoneInput from "@/common/PhoneInput.jsx";
+import Button from "@/common/Button.jsx";
 import { fetchServer, HTTPError } from "@/common/fetchServer.js";
 
 function AuthFirstSection({name, setName, phone, setPhone})
@@ -59,7 +60,7 @@ function AuthFirstSection({name, setName, phone, setPhone})
 				</div>
 			</div>
 			<div className="w-full flex justify-center relative">
-				<button type="submit" className="w-36 min-h-14 px-6 py-4 text-center bg-black text-white group-[:invalid]:bg-neutral-500">인증 요청하기</button>
+				<Button styleType="ghost" type="submit" className="w-36 min-h-14">인증 요청하기</Button>
 				<button type="button" className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300">이미 정보를 입력하신 적이 있으신가요?</button>
 			</div>
 		</form>

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -1,4 +1,5 @@
 import Input from "@/common/Input.jsx";
+import PhoneInput from "@/common/PhoneInput.jsx";
 
 function AuthFirstSection({name, setName, phone, setPhone})
 {
@@ -17,7 +18,7 @@ function AuthFirstSection({name, setName, phone, setPhone})
 					</label>
 					<label className="flex flex-col gap-3">
 						<span className="text-body-m font-bold">전화번호</span>
-						<Input text={phone} setText={setPhone} placeholder="ex) 01012345678" />
+						<PhoneInput text={phone} setText={setPhone} />
 						<p className="w-full h-4">{null}</p>
 					</label>
 				</div>

--- a/src/auth/AuthFirstSection.jsx
+++ b/src/auth/AuthFirstSection.jsx
@@ -14,11 +14,11 @@ function AuthFirstSection({name, setName, phone, setPhone})
 				<div className="flex flex-col gap-6">
 					<label className="flex flex-col gap-3">
 						<span className="text-body-m font-bold">이름</span>
-						<Input text={name} setText={setName} placeholder="ex) 홍길동" />
+						<Input text={name} setText={setName} placeholder="ex) 홍길동" required minLength="2"/>
 					</label>
 					<label className="flex flex-col gap-3">
 						<span className="text-body-m font-bold">전화번호</span>
-						<PhoneInput text={phone} setText={setPhone} />
+						<PhoneInput text={phone} setText={setPhone} required/>
 						<p className="w-full h-4">{null}</p>
 					</label>
 				</div>

--- a/src/auth/AuthModal.jsx
+++ b/src/auth/AuthModal.jsx
@@ -1,44 +1,13 @@
 import { useContext } from "react";
+import AuthFirstSection from "./AuthFirstSection.jsx";
 import { ModalCloseContext } from "@/modal/modal.jsx";
 
 function AuthModal()
 {
 	const close = useContext(ModalCloseContext);
-	const checkboxStyle = `size-4 appearance-none 
-	border border-neutral-300 checked:bg-blue-400 checked:border-0 
-	checked:bg-checked bg-center`;
 
 	return <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[40.625rem] p-6 sm:p-10 py-10 shadow bg-white relative flex flex-col gap-14">
-		<p className="text-body-l font-bold text-neutral-700">이벤트 응모를 위해<br/>간단한 정보를 입력해주세요!</p>
-		<form className="flex flex-col flex-grow relative">
-			<div className="flex flex-col gap-6">
-				<label className="flex flex-col gap-3">
-					<span>이름</span>
-					<input type="text" placeholder="ex) 홍길동" />
-				</label>
-				<label className="flex flex-col gap-3">
-					<span>전화번호</span>
-					<input placeholder="ex) 01012345678" />
-					<p className="w-full h-4">{null}</p>
-				</label>
-			</div>
-			<div className="flex flex-col gap-4 text-detail-l">	
-				<label className="flex gap-2 items-center">
-					<input type="checkbox" className={checkboxStyle}/>
-					<span className="font-bold text-neutral-600">개인정보 수집 동의(필수)</span>
-					<span className="font-medium text-neutral-300">자세히 보기</span>
-				</label>
-				<label className="flex gap-2 items-center">
-					<input type="checkbox" className={checkboxStyle}/>
-					<span className="font-bold text-neutral-600">마케팅 수신 동의(선택)</span>
-					<span className="font-medium text-neutral-300">자세히 보기</span>
-				</label>
-			</div>
-			<div className="w-full flex justify-center absolute bottom-9">
-				<button type="submit" className="w-36 h-14 px-6 py-4 text-center bg-black text-white">인증 요청하기</button>
-				<button type="button" className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300">이미 정보를 입력하신 적이 있으신가요?</button>
-			</div>
-		</form>
+		<AuthFirstSection />
 		<button className="absolute top-10 right-8" onClick={close} aria-label="닫기">
 			<img src="/icons/close.svg" alt="닫기" width="24" height="24" />
 		</button>

--- a/src/auth/AuthModal.jsx
+++ b/src/auth/AuthModal.jsx
@@ -1,13 +1,16 @@
-import { useContext } from "react";
+import { useState, useContext } from "react";
 import AuthFirstSection from "./AuthFirstSection.jsx";
 import { ModalCloseContext } from "@/modal/modal.jsx";
 
 function AuthModal()
 {
 	const close = useContext(ModalCloseContext);
+	const [name, setName] = useState("");
+	const [phone, setPhone] = useState("");
+	const firstSectionProps = {name, setName, phone, setPhone};
 
 	return <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[40.625rem] p-6 sm:p-10 py-10 shadow bg-white relative flex flex-col gap-14">
-		<AuthFirstSection />
+		<AuthFirstSection {...firstSectionProps}/>
 		<button className="absolute top-10 right-8" onClick={close} aria-label="닫기">
 			<img src="/icons/close.svg" alt="닫기" width="24" height="24" />
 		</button>

--- a/src/auth/AuthModal.jsx
+++ b/src/auth/AuthModal.jsx
@@ -1,0 +1,48 @@
+import { useContext } from "react";
+import { ModalCloseContext } from "@/modal/modal.jsx";
+
+function AuthModal()
+{
+	const close = useContext(ModalCloseContext);
+	const checkboxStyle = `size-4 appearance-none 
+	border border-neutral-300 checked:bg-blue-400 checked:border-0 
+	checked:bg-checked bg-center`;
+
+	return <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[40.625rem] p-6 sm:p-10 py-10 shadow bg-white relative flex flex-col gap-14">
+		<p className="text-body-l font-bold text-neutral-700">이벤트 응모를 위해<br/>간단한 정보를 입력해주세요!</p>
+		<form className="flex flex-col flex-grow relative">
+			<div className="flex flex-col gap-6">
+				<label className="flex flex-col gap-3">
+					<span>이름</span>
+					<input type="text" placeholder="ex) 홍길동" />
+				</label>
+				<label className="flex flex-col gap-3">
+					<span>전화번호</span>
+					<input placeholder="ex) 01012345678" />
+					<p className="w-full h-4">{null}</p>
+				</label>
+			</div>
+			<div className="flex flex-col gap-4 text-detail-l">	
+				<label className="flex gap-2 items-center">
+					<input type="checkbox" className={checkboxStyle}/>
+					<span className="font-bold text-neutral-600">개인정보 수집 동의(필수)</span>
+					<span className="font-medium text-neutral-300">자세히 보기</span>
+				</label>
+				<label className="flex gap-2 items-center">
+					<input type="checkbox" className={checkboxStyle}/>
+					<span className="font-bold text-neutral-600">마케팅 수신 동의(선택)</span>
+					<span className="font-medium text-neutral-300">자세히 보기</span>
+				</label>
+			</div>
+			<div className="w-full flex justify-center absolute bottom-9">
+				<button type="submit" className="w-36 h-14 px-6 py-4 text-center bg-black text-white">인증 요청하기</button>
+				<button type="button" className="absolute top-[calc(100%+1.25rem)] text-detail-l font-medium text-neutral-300">이미 정보를 입력하신 적이 있으신가요?</button>
+			</div>
+		</form>
+		<button className="absolute top-10 right-8" onClick={close} aria-label="닫기">
+			<img src="/icons/close.svg" alt="닫기" width="24" height="24" />
+		</button>
+	</div>
+}
+
+export default AuthModal;

--- a/src/auth/AuthModal.jsx
+++ b/src/auth/AuthModal.jsx
@@ -6,21 +6,36 @@ import { ModalCloseContext } from "@/modal/modal.jsx";
 const AUTH_INPUT_PAGE = Symbol("input");
 const AUTH_CODE_PAGE = Symbol("code");
 
-function AuthModal()
-{
-	const close = useContext(ModalCloseContext);
-	const [name, setName] = useState("");
-	const [phone, setPhone] = useState("");
-	const [page, setPage] = useState(AUTH_INPUT_PAGE);
-	const firstSectionProps = {name, setName, phone, setPhone, goNext: ()=>setPage(AUTH_CODE_PAGE)};
-	const secondSectionProps = {name, phone};
+function AuthModal() {
+  const close = useContext(ModalCloseContext);
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [page, setPage] = useState(AUTH_INPUT_PAGE);
+  const firstSectionProps = {
+    name,
+    setName,
+    phone,
+    setPhone,
+    goNext: () => setPage(AUTH_CODE_PAGE),
+  };
+  const secondSectionProps = { name, phone };
 
-	return <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[40.625rem] p-6 sm:p-10 py-10 shadow bg-white relative flex flex-col gap-14">
-		{page === AUTH_CODE_PAGE ? <AuthSecondSection {...secondSectionProps}/> : <AuthFirstSection {...firstSectionProps}/>}
-		<button className="absolute top-10 right-8" onClick={close} aria-label="닫기">
-			<img src="/icons/close.svg" alt="닫기" width="24" height="24" />
-		</button>
-	</div>
+  return (
+    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[40.625rem] p-6 sm:p-10 py-10 shadow bg-white relative flex flex-col gap-14">
+      {page === AUTH_CODE_PAGE ? (
+        <AuthSecondSection {...secondSectionProps} />
+      ) : (
+        <AuthFirstSection {...firstSectionProps} />
+      )}
+      <button
+        className="absolute top-10 right-8"
+        onClick={close}
+        aria-label="닫기"
+      >
+        <img src="/icons/close.svg" alt="닫기" width="24" height="24" />
+      </button>
+    </div>
+  );
 }
 
 export default AuthModal;

--- a/src/auth/AuthModal.jsx
+++ b/src/auth/AuthModal.jsx
@@ -1,16 +1,22 @@
 import { useState, useContext } from "react";
 import AuthFirstSection from "./AuthFirstSection.jsx";
+import AuthSecondSection from "./AuthSecondSection.jsx";
 import { ModalCloseContext } from "@/modal/modal.jsx";
+
+const AUTH_INPUT_PAGE = Symbol("input");
+const AUTH_CODE_PAGE = Symbol("code");
 
 function AuthModal()
 {
 	const close = useContext(ModalCloseContext);
 	const [name, setName] = useState("");
 	const [phone, setPhone] = useState("");
-	const firstSectionProps = {name, setName, phone, setPhone};
+	const [page, setPage] = useState(AUTH_INPUT_PAGE);
+	const firstSectionProps = {name, setName, phone, setPhone, goNext: ()=>setPage(AUTH_CODE_PAGE)};
+	const secondSectionProps = {name, phone};
 
 	return <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[40.625rem] p-6 sm:p-10 py-10 shadow bg-white relative flex flex-col gap-14">
-		<AuthFirstSection {...firstSectionProps}/>
+		{page === AUTH_CODE_PAGE ? <AuthSecondSection {...secondSectionProps}/> : <AuthFirstSection {...firstSectionProps}/>}
 		<button className="absolute top-10 right-8" onClick={close} aria-label="닫기">
 			<img src="/icons/close.svg" alt="닫기" width="24" height="24" />
 		</button>

--- a/src/auth/AuthSecondSection.jsx
+++ b/src/auth/AuthSecondSection.jsx
@@ -2,25 +2,41 @@ import { useState } from "react";
 import InputWithTimer from "./InputWithTimer.jsx";
 import Button from "@/common/Button.jsx";
 
-function AuthSecondSection({name, phone})
-{
-	const [ authNumber, setAuthNumber ] = useState("");
-	const [ errorMessage, setErrorMessage ] = useState("");
+function AuthSecondSection({ phone }) {
+  const [authNumber, setAuthNumber] = useState("");
+  //const [ errorMessage, setErrorMessage ] = useState("");
 
-	const josa = "013678".includes(phone[phone.length - 1]) ? "으" : "";
-	return  <>
-		<p className="text-body-l font-bold text-neutral-700">{phone}{josa}로<br/>인증번호를 전송했어요.</p>
-		<form className="flex flex-col flex-grow w-full relative pb-4 gap-4 group">
-			<div className="flex flex-col flex-grow justify-center items-center gap-7 px-0.5 relative h-0">
-				<InputWithTimer text={authNumber} setText={setAuthNumber} required placeholder="인증번호를 입력해주세요" />
-				<span className="absolute bottom-5 text-detail-l font-bold text-red-400">{errorMessage}</span>
-			</div>
-			<div className="w-full flex justify-center gap-5">
-				<Button styleType="filled" type="submit" className="w-36 min-h-14">인증 완료하기</Button>
-				<Button styleType="ghost" type="button" className="min-h-14">재전송</Button>
-			</div>
-		</form>
-	</>
+  const josa = "013678".includes(phone[phone.length - 1]) ? "으" : "";
+  return (
+    <>
+      <p className="text-body-l font-bold text-neutral-700">
+        {phone}
+        {josa}로<br />
+        인증번호를 전송했어요.
+      </p>
+      <form className="flex flex-col flex-grow w-full relative pb-4 gap-4 group">
+        <div className="flex flex-col flex-grow justify-center items-center gap-7 px-0.5 relative h-0">
+          <InputWithTimer
+            text={authNumber}
+            setText={setAuthNumber}
+            required
+            placeholder="인증번호를 입력해주세요"
+          />
+          <span className="absolute bottom-5 text-detail-l font-bold text-red-400">
+            {"errorMessage"}
+          </span>
+        </div>
+        <div className="w-full flex justify-center gap-5">
+          <Button styleType="filled" type="submit" className="w-36 min-h-14">
+            인증 완료하기
+          </Button>
+          <Button styleType="ghost" type="button" className="min-h-14">
+            재전송
+          </Button>
+        </div>
+      </form>
+    </>
+  );
 }
 
 export default AuthSecondSection;

--- a/src/auth/AuthSecondSection.jsx
+++ b/src/auth/AuthSecondSection.jsx
@@ -1,19 +1,21 @@
 import { useState } from "react";
-import Input from "@/common/Input.jsx";
+import InputWithTimer from "./InputWithTimer.jsx";
 import Button from "@/common/Button.jsx";
 
 function AuthSecondSection({name, phone})
 {
 	const [ authNumber, setAuthNumber ] = useState("");
+	const [ errorMessage, setErrorMessage ] = useState("");
 
 	const josa = "013678".includes(phone[phone.length - 1]) ? "으" : "";
 	return  <>
 		<p className="text-body-l font-bold text-neutral-700">{phone}{josa}로<br/>인증번호를 전송했어요.</p>
-		<form className="flex flex-col flex-grow w-full relative pb-4 group">
-			<div className="flex flex-col flex-grow justify-center items-center gap-7 px-0.5 relative h-0 overflow-y-auto">
-				<Input text={authNumber} setText={setAuthNumber} placeholder="인증번호를 입력해주세요" required/>
+		<form className="flex flex-col flex-grow w-full relative pb-4 gap-4 group">
+			<div className="flex flex-col flex-grow justify-center items-center gap-7 px-0.5 relative h-0">
+				<InputWithTimer text={authNumber} setText={setAuthNumber} required placeholder="인증번호를 입력해주세요" />
+				<span className="absolute bottom-5 text-detail-l font-bold text-red-400">{errorMessage}</span>
 			</div>
-			<div className="w-full flex justify-center gap-5 relative">
+			<div className="w-full flex justify-center gap-5">
 				<Button styleType="filled" type="submit" className="w-36 min-h-14">인증 완료하기</Button>
 				<Button styleType="ghost" type="button" className="min-h-14">재전송</Button>
 			</div>

--- a/src/auth/AuthSecondSection.jsx
+++ b/src/auth/AuthSecondSection.jsx
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import Input from "@/common/Input.jsx";
+import Button from "@/common/Button.jsx";
+
+function AuthSecondSection({name, phone})
+{
+	const [ authNumber, setAuthNumber ] = useState("");
+
+	const josa = "013678".includes(phone[phone.length - 1]) ? "으" : "";
+	return  <>
+		<p className="text-body-l font-bold text-neutral-700">{phone}{josa}로<br/>인증번호를 전송했어요.</p>
+		<form className="flex flex-col flex-grow w-full relative pb-4 group">
+			<div className="flex flex-col flex-grow justify-center items-center gap-7 px-0.5 relative h-0 overflow-y-auto">
+				<Input text={authNumber} setText={setAuthNumber} placeholder="인증번호를 입력해주세요" required/>
+			</div>
+			<div className="w-full flex justify-center gap-5 relative">
+				<Button styleType="filled" type="submit" className="w-36 min-h-14">인증 완료하기</Button>
+				<Button styleType="ghost" type="button" className="min-h-14">재전송</Button>
+			</div>
+		</form>
+	</>
+}
+
+export default AuthSecondSection;

--- a/src/auth/InputWithTimer.jsx
+++ b/src/auth/InputWithTimer.jsx
@@ -1,11 +1,14 @@
 import Input from "@/common/Input.jsx";
 
-function InputWithTimer({text, setText, timer, ...otherProps})
-{
-	return <div className="w-full flex items-center relative">
-		<Input text={text} setText={setText} {...otherProps}/>
-		<span className="absolute text-body-s text-red-400 font-bold right-4">5:00</span>
-	</div>
+function InputWithTimer({ text, setText, timer, ...otherProps }) {
+  return (
+    <div className="w-full flex items-center relative">
+      <Input text={text} setText={setText} {...otherProps} />
+      <span className="absolute text-body-s text-red-400 font-bold right-4">
+        {timer}
+      </span>
+    </div>
+  );
 }
 
 export default InputWithTimer;

--- a/src/auth/InputWithTimer.jsx
+++ b/src/auth/InputWithTimer.jsx
@@ -1,0 +1,11 @@
+import Input from "@/common/Input.jsx";
+
+function InputWithTimer({text, setText, timer, ...otherProps})
+{
+	return <div className="w-full flex items-center relative">
+		<Input text={text} setText={setText} {...otherProps}/>
+		<span className="absolute text-body-s text-red-400 font-bold right-4">5:00</span>
+	</div>
+}
+
+export default InputWithTimer;

--- a/src/auth/mock.js
+++ b/src/auth/mock.js
@@ -1,13 +1,25 @@
 import { http, HttpResponse } from "msw";
 
 const handlers = [
-  http.post("/api/v1/event-user/send-auth", async ({request}) => {
-    const {name, phoneNumber} = await request.json();
-    if(phoneNumber === "01019991999") return HttpResponse.json({error:"중복된 사용자가 있음"}, {status: 409});
-    if(name.length < 2) return HttpResponse.json({error:"응답 내용이 잘못됨"}, {status: 400});
-    if(phoneNumber.length >= 12) return HttpResponse.json({error:"응답 내용이 잘못됨"}, {status: 400});
+  http.post("/api/v1/event-user/send-auth", async ({ request }) => {
+    const { name, phoneNumber } = await request.json();
+    if (phoneNumber === "01019991999")
+      return HttpResponse.json(
+        { error: "중복된 사용자가 있음" },
+        { status: 409 },
+      );
+    if (name.length < 2)
+      return HttpResponse.json(
+        { error: "응답 내용이 잘못됨" },
+        { status: 400 },
+      );
+    if (phoneNumber.length >= 12)
+      return HttpResponse.json(
+        { error: "응답 내용이 잘못됨" },
+        { status: 400 },
+      );
 
-    return HttpResponse.json({return: true});
+    return HttpResponse.json({ return: true });
   }),
 ];
 

--- a/src/auth/mock.js
+++ b/src/auth/mock.js
@@ -5,7 +5,7 @@ const handlers = [
     const {name, phoneNumber} = await request.json();
     if(phoneNumber === "01019991999") return HttpResponse.json({error:"중복된 사용자가 있음"}, {status: 409});
     if(name.length < 2) return HttpResponse.json({error:"응답 내용이 잘못됨"}, {status: 400});
-    if(phoneNumber.length >= 11) return HttpResponse.json({error:"응답 내용이 잘못됨"}, {status: 400});
+    if(phoneNumber.length >= 12) return HttpResponse.json({error:"응답 내용이 잘못됨"}, {status: 400});
 
     return HttpResponse.json({return: true});
   }),

--- a/src/auth/mock.js
+++ b/src/auth/mock.js
@@ -1,0 +1,14 @@
+import { http, HttpResponse } from "msw";
+
+const handlers = [
+  http.post("/api/v1/event-user/send-auth", async ({request}) => {
+    const {name, phoneNumber} = await request.json();
+    if(phoneNumber === "01019991999") return HttpResponse.json({error:"중복된 사용자가 있음"}, {status: 409});
+    if(name.length < 2) return HttpResponse.json({error:"응답 내용이 잘못됨"}, {status: 400});
+    if(phoneNumber.length >= 11) return HttpResponse.json({error:"응답 내용이 잘못됨"}, {status: 400});
+
+    return HttpResponse.json({return: true});
+  }),
+];
+
+export default handlers;

--- a/src/common/Button.jsx
+++ b/src/common/Button.jsx
@@ -1,20 +1,33 @@
-function Button({styleType, children, type="button", className, ...otherProps})
-{
-	const isSubmit = !(type === "reset" || type === "button");
+function Button({
+  styleType,
+  children,
+  type = "button",
+  className,
+  ...otherProps
+}) {
+  const isSubmit = !(type === "reset" || type === "button");
 
-	const filledStyle = `bg-black text-white active:bg-neutral-700 active:text-neutral-200
+  const filledStyle = `bg-black text-white active:bg-neutral-700 active:text-neutral-200
 	hover:bg-neutral-700 disabled:bg-neutral-600 disabled:text-neutral-400
 	${isSubmit ? "group-[:invalid]:bg-neutral-600 group-[:invalid]:text-neutral-400" : ""}`;
 
-	const ghostStyle = `bg-white text-black shadow-[0_0_0_2px_inset_currentColor]
+  const ghostStyle = `bg-white text-black shadow-[0_0_0_2px_inset_currentColor]
 	active:bg-neutral-50 active:text-neutral-400 hover:bg-neutral-50
 	disabled:text-neutral-200 ${isSubmit ? "group-[:invalid]:text-neutral-200" : ""}`;
 
-	const defaultStyle = `px-6 py-4 text-body-m font-bold text-center 
+  const defaultStyle = `px-6 py-4 text-body-m font-bold text-center 
 	disabled:cursor-default ${isSubmit ? "group-[:invalid]:cursor-default" : ""}`;
 
-	const typedStyle = styleType === "filled" ? filledStyle : ghostStyle;
-	return <button className={`${defaultStyle} ${typedStyle} ${className}`} type={type} {...otherProps}>{children}</button>
+  const typedStyle = styleType === "filled" ? filledStyle : ghostStyle;
+  return (
+    <button
+      className={`${defaultStyle} ${typedStyle} ${className}`}
+      type={type}
+      {...otherProps}
+    >
+      {children}
+    </button>
+  );
 }
 
 export default Button;

--- a/src/common/Button.jsx
+++ b/src/common/Button.jsx
@@ -1,16 +1,20 @@
-function Button({styleType, children, className, ...otherProps})
+function Button({styleType, children, type="button", className, ...otherProps})
 {
+	const isSubmit = !(type === "reset" || type === "button");
+
 	const filledStyle = `bg-black text-white active:bg-neutral-700 active:text-neutral-200
 	hover:bg-neutral-700 disabled:bg-neutral-600 disabled:text-neutral-400
-	group-[:invalid]:bg-neutral-600 group-[:invalid]:text-neutral-400`;
+	${isSubmit ? "group-[:invalid]:bg-neutral-600 group-[:invalid]:text-neutral-400" : ""}`;
 
 	const ghostStyle = `bg-white text-black shadow-[0_0_0_2px_inset_currentColor]
 	active:bg-neutral-50 active:text-neutral-400 hover:bg-neutral-50
-	disabled:text-neutral-200 group-[:invalid]:text-neutral-200`;
+	disabled:text-neutral-200 ${isSubmit ? "group-[:invalid]:text-neutral-200" : ""}`;
 
-	const defaultStyle = `px-6 py-4 text-body-m font-bold text-center disabled:pointer-events-none group-[:invalid]:pointer-events-none`;
+	const defaultStyle = `px-6 py-4 text-body-m font-bold text-center 
+	disabled:cursor-default ${isSubmit ? "group-[:invalid]:cursor-default" : ""}`;
+
 	const typedStyle = styleType === "filled" ? filledStyle : ghostStyle;
-	return <button className={`${defaultStyle} ${typedStyle} ${className}`} {...otherProps}>{children}</button>
+	return <button className={`${defaultStyle} ${typedStyle} ${className}`} type={type} {...otherProps}>{children}</button>
 }
 
 export default Button;

--- a/src/common/Button.jsx
+++ b/src/common/Button.jsx
@@ -1,0 +1,16 @@
+function Button({styleType, children, className, ...otherProps})
+{
+	const filledStyle = `bg-black text-white active:bg-neutral-700 active:text-neutral-200
+	hover:bg-neutral-700 disabled:bg-neutral-600 disabled:text-neutral-400
+	group-[:invalid]:bg-neutral-600 group-[:invalid]:text-neutral-400`;
+
+	const ghostStyle = `bg-white text-black shadow-[0_0_0_2px_inset_currentColor]
+	active:bg-neutral-50 active:text-neutral-400 hover:bg-neutral-50
+	disabled:text-neutral-200 group-[:invalid]:text-neutral-200`;
+
+	const defaultStyle = `px-6 py-4 text-body-m font-bold text-center disabled:pointer-events-none group-[:invalid]:pointer-events-none`;
+	const typedStyle = styleType === "filled" ? filledStyle : ghostStyle;
+	return <button className={`${defaultStyle} ${typedStyle} ${className}`} {...otherProps}>{children}</button>
+}
+
+export default Button;

--- a/src/common/Input.jsx
+++ b/src/common/Input.jsx
@@ -1,0 +1,13 @@
+function Input({text, setText, placeholder, isError})
+{
+	const inputboxStyle = `w-full h-14 p-4 bg-neutral-50 rounded text-body-m font-medium
+	focus:bg-white focus:outline-neutral-800
+	placeholder:text-neutral-200`;
+
+	const errorStyle = `bg-white outline-red-500 focus:outline-red-500`;
+
+	return <input className={`${inputboxStyle} ${isError ? errorStyle : ""}`} 
+	type="text" value={text} onChange={(e)=>setText(e.target.value)} placeholder={placeholder} />
+}
+
+export default Input;

--- a/src/common/Input.jsx
+++ b/src/common/Input.jsx
@@ -1,13 +1,16 @@
-function Input({text, setText, placeholder, isError})
+function Input({text, setText, isError, ...otherProps})
 {
 	const inputboxStyle = `w-full h-14 p-4 bg-neutral-50 rounded text-body-m font-medium
-	focus:bg-white focus:outline-neutral-800
+	focus:bg-white focus:outline-neutral-800 
 	placeholder:text-neutral-200`;
 
-	const errorStyle = `bg-white outline-red-500 focus:outline-red-500`;
+	const errorStyle = `bg-white outline outline-red-500 focus:outline-red-500`;
 
-	return <input className={`${inputboxStyle} ${isError ? errorStyle : ""}`} 
-	type="text" value={text} onChange={(e)=>setText(e.target.value)} placeholder={placeholder} />
+	const errorInputStyle = `invalid:outline invalid:outline-red-500
+	invalid:focus:outline invalid:focus:outline-red-500`;
+
+	return <input className={`${inputboxStyle} ${isError ? errorStyle : ""} ${/^\s*$/.test(text) ? "" : errorInputStyle}`} 
+	type="text" value={text} onChange={(e)=>setText(e.target.value)} {...otherProps} />
 }
 
 export default Input;

--- a/src/common/Input.jsx
+++ b/src/common/Input.jsx
@@ -1,16 +1,22 @@
-function Input({text, setText, isError, ...otherProps})
-{
-	const inputboxStyle = `w-full h-14 p-4 bg-neutral-50 rounded text-body-m font-medium
+function Input({ text, setText, isError, ...otherProps }) {
+  const inputboxStyle = `w-full h-14 p-4 bg-neutral-50 rounded text-body-m font-medium
 	focus:bg-white focus:outline-neutral-800 
 	placeholder:text-neutral-200`;
 
-	const errorStyle = `bg-white outline outline-red-500 focus:outline-red-500`;
+  const errorStyle = `bg-white outline outline-red-500 focus:outline-red-500`;
 
-	const errorInputStyle = `invalid:outline invalid:outline-red-500
+  const errorInputStyle = `invalid:outline invalid:outline-red-500
 	invalid:focus:outline invalid:focus:outline-red-500`;
 
-	return <input className={`${inputboxStyle} ${isError ? errorStyle : ""} ${/^\s*$/.test(text) ? "" : errorInputStyle}`} 
-	type="text" value={text} onChange={(e)=>setText(e.target.value)} {...otherProps} />
+  return (
+    <input
+      className={`${inputboxStyle} ${isError ? errorStyle : ""} ${/^\s*$/.test(text) ? "" : errorInputStyle}`}
+      type="text"
+      value={text}
+      onChange={(e) => setText(e.target.value)}
+      {...otherProps}
+    />
+  );
 }
 
 export default Input;

--- a/src/common/PhoneInput.jsx
+++ b/src/common/PhoneInput.jsx
@@ -1,0 +1,18 @@
+import Input from "./Input.jsx";
+
+function PhoneInput({text, setText, ...otherProps})
+{
+	function addHyphen(value)
+	{
+		const plain = value.replace(/\D/g, "");
+
+		if(plain.length < 4) return plain;
+		if(plain.length <= 7) return plain.replace(/^(\d{3})(\d{0,4})$/, "$1-$2");
+		if(plain.length <= 10) return plain.replace(/^(\d{3})(\d{3})(\d{0,4})$/, "$1-$2-$3");
+		return plain.replace(/^(\d{3})(\d{4})(\d{4,})$/, "$1-$2-$3");
+	}
+	return <Input text={text} setText={(value)=>setText(addHyphen(value))} placeholder="-를 제외한 숫자를 입력하세요." 
+	{...otherProps} maxLength="13"/>
+}
+
+export default PhoneInput;

--- a/src/common/PhoneInput.jsx
+++ b/src/common/PhoneInput.jsx
@@ -1,18 +1,24 @@
 import Input from "./Input.jsx";
 
-function PhoneInput({text, setText, ...otherProps})
-{
-	function addHyphen(value)
-	{
-		const plain = value.replace(/\D/g, "");
+function PhoneInput({ text, setText, ...otherProps }) {
+  function addHyphen(value) {
+    const plain = value.replace(/\D/g, "");
 
-		if(plain.length < 4) return plain;
-		if(plain.length <= 7) return plain.replace(/^(\d{3})(\d{0,4})$/, "$1-$2");
-		if(plain.length <= 10) return plain.replace(/^(\d{3})(\d{3})(\d{0,4})$/, "$1-$2-$3");
-		return plain.replace(/^(\d{3})(\d{4})(\d{4,})$/, "$1-$2-$3");
-	}
-	return <Input text={text} setText={(value)=>setText(addHyphen(value))} placeholder="-를 제외한 숫자를 입력하세요." 
-	{...otherProps} maxLength="13"/>
+    if (plain.length < 4) return plain;
+    if (plain.length <= 7) return plain.replace(/^(\d{3})(\d{0,4})$/, "$1-$2");
+    if (plain.length <= 10)
+      return plain.replace(/^(\d{3})(\d{3})(\d{0,4})$/, "$1-$2-$3");
+    return plain.replace(/^(\d{3})(\d{4})(\d{4,})$/, "$1-$2-$3");
+  }
+  return (
+    <Input
+      text={text}
+      setText={(value) => setText(addHyphen(value))}
+      placeholder="-를 제외한 숫자를 입력하세요."
+      {...otherProps}
+      maxLength="13"
+    />
+  );
 }
 
 export default PhoneInput;

--- a/src/mock.js
+++ b/src/mock.js
@@ -1,7 +1,8 @@
 import { setupWorker } from "msw/browser";
 import commentHandler from "./comment/mock.js";
+import authHandler from "./auth/mock.js";
 
 // mocking은 기본적으로 각 feature 폴더 내의 mock.js로 정의합니다.
 // 새로운 feature의 mocking을 추가하셨으면, mock.js의 setupWorker 내부 함수에 인자를 spread 연산자를 이용해 추가해주세요.
 // 예시 : export default setupWorker(...authHandler, ...questionHandler, ...articleHandler);
-export default setupWorker(...commentHandler);
+export default setupWorker(...commentHandler, ...authHandler);

--- a/tailwind.redefine.js
+++ b/tailwind.redefine.js
@@ -73,5 +73,8 @@ export default {
   },
   transitionTimingFunction: {
     'in-out-cubic': 'cubic-bezier(0.645, 0.045, 0.355, 1.000)'
+  },
+  backgroundImage: {
+    "checked": "url('/icons/checked.svg')"
   }
 };

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+	"rewrites": [
+		{
+			"source": "/api/:path*",
+			"destination": "http://13.125.76.97:8080/api/:path*"
+		}
+	]
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #17 

# 📝 작업 내용

> 리버스 프록싱을 적용했습니다.
`/api`로 시작하는 모든 것들은 전부 백엔드 측으로 보내도록 구성했습니다.

> 정보등록 1번째 페이지를 구현했습니다.
- `/api/v1/event-user/send-auth`로 api까지 쏘고, 에러 핸들링하고, 다음 섹션으로 넘어가는 것까지 구성했습니다.

> 정보등록 2번째 페이지의 스타일을 구성했습니다.
- 아직 동작은 안 합니다.

> 기타 모달에서 쓰이는 공통 컴포넌트를 추가했습니다.
- Button, Input 컴포넌트를 구현했습니다. 사용방법은 나중에 집가서 정리할 생각입니다.