### PR TITLE
[feat] 스크롤 따라 헤더바 상태 변경되는 것 구현

### DIFF
--- a/src/comment/index.jsx
+++ b/src/comment/index.jsx
@@ -4,7 +4,7 @@ import { useRef } from "react";
 import useSectionInitialize from "../scroll/useSectionInitialize";
 
 function CommentSection() {
-  const SECTION_IDX = 2;
+  const SECTION_IDX = 3;
   const sectionRef = useRef(null);
   useSectionInitialize(SECTION_IDX, sectionRef);
 

--- a/src/detailInformation/index.jsx
+++ b/src/detailInformation/index.jsx
@@ -5,7 +5,7 @@ import { useRef } from "react";
 import useSectionInitialize from "../scroll/useSectionInitialize.js";
 
 function DetailInformation() {
-  const SECTION_IDX = 1;
+  const SECTION_IDX = 2;
   const sectionRef = useRef(null);
   useSectionInitialize(SECTION_IDX, sectionRef);
 

--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -1,17 +1,24 @@
 import style from "./index.module.css";
 import scrollTo from "../scroll/scrollTo";
 import { useSectionStore } from "../scroll/store";
+import { useEffect, useState } from "react";
 
 export default function Header() {
   const ITEM_WIDTH = 96; // w-24
   const ITEM_GAP = 32; // gap-8
-  const currentSection = useSectionStore((state) => state.currentSection);
+  const isVisibleList = useSectionStore((state) => state.isVisibleList);
+  const [currentSection, setCurrentSection] = useState(0);
   const scrollSectionList = [
     "추첨 이벤트",
     "차량 상세정보",
     "기대평",
     "선착순 이벤트",
   ];
+
+  useEffect(() => {
+    const idx = isVisibleList.findIndex((value) => value === true);
+    setCurrentSection(idx);
+  }, [isVisibleList]);
 
   function gotoTop() {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -30,14 +37,14 @@ export default function Header() {
   }
 
   function scrollDynamicStyle() {
-    if (currentSection < 0) return;
-
-    const position = Math.floor(
-      ITEM_WIDTH / 4 + currentSection * (ITEM_WIDTH + ITEM_GAP),
-    );
-    return {
-      "--pos": position,
-    };
+    if (currentSection > 0) {
+      const position = Math.floor(
+        ITEM_WIDTH / 4 + (currentSection - 1) * (ITEM_WIDTH + ITEM_GAP),
+      );
+      return {
+        "--pos": position,
+      };
+    }
   }
 
   return (
@@ -53,8 +60,8 @@ export default function Header() {
         {scrollSectionList.map((scrollSection, index) => (
           <div
             key={index}
-            onClick={() => onClickScrollSection(index)}
-            className={`flex justify-center items-center w-24 cursor-pointer ${currentSection === index ? "text-black" : "text-neutral-300"}`}
+            onClick={() => onClickScrollSection(index + 1)}
+            className={`flex justify-center items-center w-24 cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
           >
             {scrollSection}
           </div>
@@ -62,7 +69,7 @@ export default function Header() {
 
         <div
           style={scrollDynamicStyle()}
-          className={`w-[50px] h-[3px] bg-black transition ease-in-out duration-200 absolute bottom-0 left-0 ${currentSection < 0 ? "hidden" : style.moveBar}`}
+          className={`w-[50px] h-[3px] bg-black transition ease-in-out duration-200 absolute bottom-0 left-0 ${currentSection > 0 ? style.moveBar : "hidden"}`}
         />
       </div>
 

--- a/src/header/index.jsx
+++ b/src/header/index.jsx
@@ -1,24 +1,19 @@
 import style from "./index.module.css";
 import scrollTo from "../scroll/scrollTo";
 import { useSectionStore } from "../scroll/store";
-import { useEffect, useState } from "react";
 
 export default function Header() {
   const ITEM_WIDTH = 96; // w-24
   const ITEM_GAP = 32; // gap-8
-  const isVisibleList = useSectionStore((state) => state.isVisibleList);
-  const [currentSection, setCurrentSection] = useState(0);
+  const currentSection = useSectionStore((state) => {
+    return state.isVisibleList.findIndex((value) => value === true);
+  });
   const scrollSectionList = [
     "추첨 이벤트",
     "차량 상세정보",
     "기대평",
     "선착순 이벤트",
   ];
-
-  useEffect(() => {
-    const idx = isVisibleList.findIndex((value) => value === true);
-    setCurrentSection(idx);
-  }, [isVisibleList]);
 
   function gotoTop() {
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -37,14 +32,14 @@ export default function Header() {
   }
 
   function scrollDynamicStyle() {
-    if (currentSection > 0) {
-      const position = Math.floor(
-        ITEM_WIDTH / 4 + (currentSection - 1) * (ITEM_WIDTH + ITEM_GAP),
-      );
-      return {
-        "--pos": position,
-      };
-    }
+    if (currentSection <= 0) return;
+
+    const position = Math.floor(
+      ITEM_WIDTH / 4 + (currentSection - 1) * (ITEM_WIDTH + ITEM_GAP),
+    );
+    return {
+      "--pos": position,
+    };
   }
 
   return (

--- a/src/interactions/index.jsx
+++ b/src/interactions/index.jsx
@@ -2,7 +2,7 @@ import { useRef } from "react";
 import useSectionInitialize from "../scroll/useSectionInitialize";
 
 export default function InteractionPage() {
-  const SECTION_IDX = 0;
+  const SECTION_IDX = 1;
   const sectionRef = useRef(null);
   useSectionInitialize(SECTION_IDX, sectionRef);
 

--- a/src/scroll/store.js
+++ b/src/scroll/store.js
@@ -1,13 +1,18 @@
 import { create } from "zustand";
 
 export const useSectionStore = create((set) => ({
-  sectionList: [null, null, null, null],
-  currentSection: -1,
-  setCurrentSection: (newSection) => set({ currentSection: newSection }),
+  sectionList: [null, null, null, null, null],
+  isVisibleList: [false, false, false, false, false],
   uploadSection: (index, section) =>
     set((state) => {
       const updatedList = [...state.sectionList];
       updatedList[index] = section;
       return { sectionList: updatedList };
+    }),
+  setIsVisibleList: (index, value) =>
+    set((state) => {
+      const updatedList = [...state.isVisibleList];
+      updatedList[index] = value;
+      return { isVisibleList: updatedList };
     }),
 }));

--- a/src/scroll/useSectionInitialize.js
+++ b/src/scroll/useSectionInitialize.js
@@ -3,9 +3,7 @@ import { useSectionStore } from "./store";
 
 export default function useSectionInitialize(SECTION_IDX, sectionRef) {
   const uploadSection = useSectionStore((state) => state.uploadSection);
-  const setCurrentSection = useSectionStore((state) => state.setCurrentSection);
-  const currentSection = useSectionStore((state) => state.currentSection);
-
+  const setIsVisibleList = useSectionStore((state) => state.setIsVisibleList);
   useEffect(() => {
     const sectionDOM = sectionRef.current;
     if (sectionDOM) {
@@ -15,12 +13,10 @@ export default function useSectionInitialize(SECTION_IDX, sectionRef) {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            // 미구현
-          }
+          setIsVisibleList(SECTION_IDX, entry.isIntersecting);
         });
       },
-      { threshold: 0.05 },
+      { threshold: 0.01 },
     );
 
     if (sectionDOM) {
@@ -35,7 +31,6 @@ export default function useSectionInitialize(SECTION_IDX, sectionRef) {
     SECTION_IDX,
     sectionRef,
     uploadSection,
-    setCurrentSection,
-    currentSection,
+    setIsVisibleList,
   ]);
 }

--- a/src/simpleInformation/index.jsx
+++ b/src/simpleInformation/index.jsx
@@ -4,7 +4,7 @@ import ContentSection from "./contentSection";
 import useSectionInitialize from "../scroll/useSectionInitialize";
 
 export default function SimpleInformation() {
-  const SECTION_IDX = -1;
+  const SECTION_IDX = 0;
   const sectionRef = useRef(null);
   const contentList = JSONData.content;
   useSectionInitialize(SECTION_IDX, sectionRef);


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #64 

# 📝 작업 내용

> 현재 스크롤에 따라 헤더 상단 검정 바가 움직입니다. 명세서에 최대한 근접하고 쉬운 구현을 위해 추첨이벤트 섹션 직전의 차량 간단 설명 섹션 DOM의 인덱스를 0으로 두고, 그 다음부터 순서대로 1, 2, 3, 4로 지정했습니다. 때문에 헤더바에서 인덱스 관련해서 약간의 수정이 있었습니다.(헤더바 리스트의 인덱스는 0, 1, 2, 3 뿐이기 때문에 실제와 1씩 차이가 나기 때문)
현재 스크롤이 정확히 어느 섹션에 위치해 있는지를 전역상태에서 판단하고 저장하는 것이 불가능하다고 판단하여, 전역상태에서는 말 그대로 '현재 섹션'은 저장하지 않고, 현재 뷰포트와 각 섹션이 겹치는지 안 겹치는 지를 나타내는 불리언 배열을 저장합니다. 헤더바에서는 이 불리언 배열의 가장 먼저 true가 나오는 요소의 인덱스를 가지고 상단 검정 바 상태를 변경합니다. 즉, 검정 바의 위치는 전역 상태의 불리언 배열에 종속적입니다. 헤더바에서 섹션 클릭을 통해 스크롤을 이동하는 행동은 말 그대로 스크롤만 이동시킬 뿐 헤더바의 상태를 직접적으로 변경시키지 않습니다.

