### PR TITLE
[feat] 어드민 페이지 로그인 기능 추가, 자동 로그아웃 로직 구현

### DIFF
--- a/src/adminPage/App.jsx
+++ b/src/adminPage/App.jsx
@@ -1,4 +1,5 @@
 import { Route, Routes } from "react-router-dom";
+import LoginPage from "./pages/LoginPage.jsx";
 
 function App() {
   return (
@@ -13,7 +14,7 @@ function App() {
         <Route path="/events" element={<div>이벤트 목록 화면</div>} />
         <Route path="/comments/:id" element={<div>기대평 화면</div>} />
         <Route path="/comments" element={<div>기대평 검색 화면</div>} />
-        <Route path="/login" element={<div>로그인 화면</div>} />
+        <Route path="/login" element={<LoginPage />} />
         <Route path="/" element={<div>hello</div>} />
       </Routes>
     </>

--- a/src/adminPage/App.jsx
+++ b/src/adminPage/App.jsx
@@ -1,5 +1,6 @@
 import { Route, Routes } from "react-router-dom";
 import LoginPage from "./pages/LoginPage.jsx";
+import EventsPage from "./pages/EventsPage.jsx";
 
 function App() {
   return (
@@ -11,7 +12,7 @@ function App() {
           element={<div>event 생성 화면</div>}
         />
         <Route path="/events/:id" element={<div>event 보는 화면</div>} />
-        <Route path="/events" element={<div>이벤트 목록 화면</div>} />
+        <Route path="/events" element={<EventsPage />} />
         <Route path="/comments/:id" element={<div>기대평 화면</div>} />
         <Route path="/comments" element={<div>기대평 검색 화면</div>} />
         <Route path="/login" element={<LoginPage />} />

--- a/src/adminPage/App.jsx
+++ b/src/adminPage/App.jsx
@@ -1,22 +1,37 @@
+import { useEffect } from "react";
 import { Route, Routes } from "react-router-dom";
 import LoginPage from "./pages/LoginPage.jsx";
 import EventsPage from "./pages/EventsPage.jsx";
+import ProtectedRoute from "./pages/ProtectedRoute.jsx";
+import RootRoute from "./pages/RootRoute.jsx";
+
+import { initLoginState, logout } from "@admin/auth/store.js";
+import useLogoutMiddleware from "@common/dataFetch/initLogoutMiddleware";
 
 function App() {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    history.scrollRestoration = "manual";
+    initLoginState();
+  }, []);
+  useLogoutMiddleware(logout);
+
   return (
     <>
       <Routes>
-        <Route
-          exact
-          path="/events/create"
-          element={<div>event 생성 화면</div>}
-        />
-        <Route path="/events/:id" element={<div>event 보는 화면</div>} />
-        <Route path="/events" element={<EventsPage />} />
-        <Route path="/comments/:id" element={<div>기대평 화면</div>} />
-        <Route path="/comments" element={<div>기대평 검색 화면</div>} />
+        <Route element={<ProtectedRoute />}>
+          <Route
+            exact
+            path="/events/create"
+            element={<div>event 생성 화면</div>}
+          />
+          <Route path="/events/:id" element={<div>event 보는 화면</div>} />
+          <Route path="/events" element={<EventsPage />} />
+          <Route path="/comments/:id" element={<div>기대평 화면</div>} />
+          <Route path="/comments" element={<div>기대평 검색 화면</div>} />
+        </Route>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/" element={<div>hello</div>} />
+        <Route path="/" element={<RootRoute />} />
       </Routes>
     </>
   );

--- a/src/adminPage/mock.js
+++ b/src/adminPage/mock.js
@@ -1,6 +1,7 @@
 import { setupWorker } from "msw/browser";
+import authHandler from "@admin/auth/mock.js";
 
 // mocking은 기본적으로 각 feature 폴더 내의 mock.js로 정의합니다.
 // 새로운 feature의 mocking을 추가하셨으면, mock.js의 setupWorker 내부 함수에 인자를 spread 연산자를 이용해 추가해주세요.
 // 예시 : export default setupWorker(...authHandler, ...questionHandler, ...articleHandler);
-export default setupWorker();
+export default setupWorker(...authHandler);

--- a/src/adminPage/pages/EventsPage.jsx
+++ b/src/adminPage/pages/EventsPage.jsx
@@ -1,9 +1,10 @@
 import Container from "@admin/components/Container.jsx";
-function EventsPage()
-{
-	return <Container>
-		<div className="h-[300px]">이벤트 테스트</div>
-	</Container>
+function EventsPage() {
+  return (
+    <Container>
+      <div className="h-[300px]">이벤트 테스트</div>
+    </Container>
+  );
 }
 
 export default EventsPage;

--- a/src/adminPage/pages/EventsPage.jsx
+++ b/src/adminPage/pages/EventsPage.jsx
@@ -1,0 +1,9 @@
+import Container from "@admin/components/Container.jsx";
+function EventsPage()
+{
+	return <Container>
+		<div className="h-[300px]">이벤트 테스트</div>
+	</Container>
+}
+
+export default EventsPage;

--- a/src/adminPage/pages/LoginPage.jsx
+++ b/src/adminPage/pages/LoginPage.jsx
@@ -1,8 +1,9 @@
 import Container from "@admin/components/Container.jsx";
+import LoginSection from "@admin/auth/LoginSection.jsx";
 function LoginPage()
 {
 	return <Container>
-		<div className="h-[3000px]">컨테이너 테스트</div>
+		<LoginSection />
 	</Container>
 }
 

--- a/src/adminPage/pages/LoginPage.jsx
+++ b/src/adminPage/pages/LoginPage.jsx
@@ -2,7 +2,7 @@ import Container from "@admin/components/Container.jsx";
 function LoginPage()
 {
 	return <Container>
-		<div className="h-[300px]">컨테이너 테스트</div>
+		<div className="h-[3000px]">컨테이너 테스트</div>
 	</Container>
 }
 

--- a/src/adminPage/pages/LoginPage.jsx
+++ b/src/adminPage/pages/LoginPage.jsx
@@ -1,0 +1,9 @@
+import Container from "@admin/components/Container.jsx";
+function LoginPage()
+{
+	return <Container>
+		<div className="h-[300px]">컨테이너 테스트</div>
+	</Container>
+}
+
+export default LoginPage;

--- a/src/adminPage/pages/LoginPage.jsx
+++ b/src/adminPage/pages/LoginPage.jsx
@@ -1,10 +1,11 @@
 import Container from "@admin/components/Container.jsx";
 import LoginSection from "@admin/auth/LoginSection.jsx";
-function LoginPage()
-{
-	return <Container>
-		<LoginSection />
-	</Container>
+function LoginPage() {
+  return (
+    <Container>
+      <LoginSection />
+    </Container>
+  );
 }
 
 export default LoginPage;

--- a/src/adminPage/pages/ProtectedRoute.jsx
+++ b/src/adminPage/pages/ProtectedRoute.jsx
@@ -5,14 +5,14 @@ import Container from "@admin/components/Container.jsx";
 import useUserStore from "@admin/auth/store.js";
 
 function ProtectedRoute() {
-  const isLogin = useUserStore( store=>store.isLogin );
+  const isLogin = useUserStore((store) => store.isLogin);
   const navigate = useNavigate();
 
-  useEffect( ()=>{
-    if (!isLogin) navigate("/login", {replace: true});
-  }, [isLogin]);
+  useEffect(() => {
+    if (!isLogin) navigate("/login", { replace: true });
+  }, [isLogin, navigate]);
 
-  if(!isLogin) return <Container />
+  if (!isLogin) return <Container />;
   return <Outlet />;
 }
 

--- a/src/adminPage/pages/ProtectedRoute.jsx
+++ b/src/adminPage/pages/ProtectedRoute.jsx
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useNavigate, Outlet } from "react-router-dom";
+
+import Container from "@admin/components/Container.jsx";
+import useUserStore from "@admin/auth/store.js";
+
+function ProtectedRoute() {
+  const isLogin = useUserStore( store=>store.isLogin );
+  const navigate = useNavigate();
+
+  useEffect( ()=>{
+    if (!isLogin) navigate("/login", {replace: true});
+  }, [isLogin]);
+
+  if(!isLogin) return <Container />
+  return <Outlet />;
+}
+
+export default ProtectedRoute;

--- a/src/adminPage/pages/RootRoute.jsx
+++ b/src/adminPage/pages/RootRoute.jsx
@@ -1,8 +1,8 @@
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate } from "react-router-dom";
 import useUserStore from "@admin/auth/store.js";
 
 function RootRoute() {
-  const isLogin = useUserStore( store=>store.isLogin );
+  const isLogin = useUserStore((store) => store.isLogin);
 
   if (isLogin) return <Navigate to="/events" replace />;
   return <Navigate to="/login" replace />;

--- a/src/adminPage/pages/RootRoute.jsx
+++ b/src/adminPage/pages/RootRoute.jsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from "react-router-dom";
+import useUserStore from "@admin/auth/store.js";
+
+function RootRoute() {
+  const isLogin = useUserStore( store=>store.isLogin );
+
+  if (isLogin) return <Navigate to="/events" replace />;
+  return <Navigate to="/login" replace />;
+}
+
+export default RootRoute;

--- a/src/adminPage/shared/auth/LoginSection.jsx
+++ b/src/adminPage/shared/auth/LoginSection.jsx
@@ -1,17 +1,40 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
+import { login } from "./store.js";
+import { fetchServer, handleError } from "@common/dataFetch/fetchServer.js";
 import Input from "@common/components/Input.jsx";
 import Button from "@common/components/Button.jsx";
 
+const loginErrorHandler = {
+	400: "잘못된 입력입니다!",
+	401: "로그인에 실패했습니다!"
+}
+
 function LoginSection()
 {
+	const navigate = useNavigate();
 	const [id, setId] = useState("");
 	const [password, setPassword] = useState("");
-	function onSubmit(e)
+	const [errorMessage, setErrorMessage] = useState("");
+	async function onSubmit(e)
 	{
 		e.preventDefault();
+		const config = {method: "post", body:{userName: id, password}};
+		setErrorMessage("");
+		fetchServer("/api/v1/admin/auth/signin", config)
+			.then( ({token})=>{
+				login(token);
+				navigate("/events", {replace: true});
+			} )
+			.catch(handleError(loginErrorHandler))
+			.catch( e=>{
+				setId("");
+				setPassword("");
+				setErrorMessage(e.message);
+			} );
 	}
-	return <form className="w-full h-full max-w-[32rem] max-h-[20rem] p-8 flex flex-col gap-8 bg-white shadow-md rounded-3xl group" onSubmit={onSubmit}>
+	return <form className="w-full h-full max-w-[32rem] max-h-[40rem] p-8 flex flex-col gap-8 bg-white shadow-md rounded-3xl group" onSubmit={onSubmit}>
 		<div className="flex flex-col gap-4">
 			<label>
 				<span className="text-detail-l text-neutral-600">아이디</span>
@@ -24,7 +47,10 @@ function LoginSection()
 				/>
 			</label>
 		</div>
-		<Button type="submit">로그인</Button>
+		<div className="flex flex-col relative items-center">
+			<Button className="w-full" type="submit">로그인</Button>
+			<span className="absolute -bottom-4 text-detail-l text-red-400">{errorMessage}</span>
+		</div>
 	</form>
 }
 

--- a/src/adminPage/shared/auth/LoginSection.jsx
+++ b/src/adminPage/shared/auth/LoginSection.jsx
@@ -7,51 +7,72 @@ import Input from "@common/components/Input.jsx";
 import Button from "@common/components/Button.jsx";
 
 const loginErrorHandler = {
-	400: "잘못된 입력입니다!",
-	401: "로그인에 실패했습니다!"
-}
+  400: "잘못된 입력입니다!",
+  401: "로그인에 실패했습니다!",
+};
 
-function LoginSection()
-{
-	const navigate = useNavigate();
-	const [id, setId] = useState("");
-	const [password, setPassword] = useState("");
-	const [errorMessage, setErrorMessage] = useState("");
-	async function onSubmit(e)
-	{
-		e.preventDefault();
-		const config = {method: "post", body:{userName: id, password}};
-		setErrorMessage("");
-		fetchServer("/api/v1/admin/auth/signin", config)
-			.then( ({token})=>{
-				login(token);
-				navigate("/events", {replace: true});
-			} )
-			.catch(handleError(loginErrorHandler))
-			.catch( e=>{
-				setId("");
-				setPassword("");
-				setErrorMessage(e.message);
-			} );
-	}
-	return <form className="w-full h-full max-w-[32rem] max-h-[40rem] p-8 flex flex-col gap-8 bg-white shadow-md rounded-3xl group" onSubmit={onSubmit}>
-		<div className="flex flex-col gap-4">
-			<label>
-				<span className="text-detail-l text-neutral-600">아이디</span>
-				<Input text={id} setText={setId} placeholder="ID를 입력하세요." required maxLength="12" pattern="^[\-\w]+$"/>
-			</label>
-			<label>
-				<span className="text-detail-l text-neutral-600">비밀번호</span>
-				<Input text={password} setText={setPassword} type="password" placeholder="비밀번호 입력하세요." required
-				minLength="8" maxLength="16" pattern="^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$"
-				/>
-			</label>
-		</div>
-		<div className="flex flex-col relative items-center">
-			<Button className="w-full" type="submit">로그인</Button>
-			<span className="absolute -bottom-4 text-detail-l text-red-400">{errorMessage}</span>
-		</div>
-	</form>
+function LoginSection() {
+  const navigate = useNavigate();
+  const [id, setId] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  async function onSubmit(e) {
+    e.preventDefault();
+    const config = { method: "post", body: { userName: id, password } };
+    setErrorMessage("");
+    fetchServer("/api/v1/admin/auth/signin", config)
+      .then(({ token }) => {
+        login(token);
+        navigate("/events", { replace: true });
+      })
+      .catch(handleError(loginErrorHandler))
+      .catch((e) => {
+        setId("");
+        setPassword("");
+        setErrorMessage(e.message);
+      });
+  }
+  return (
+    <form
+      className="w-full h-full max-w-[32rem] max-h-[40rem] p-8 flex flex-col gap-8 bg-white shadow-md rounded-3xl group"
+      onSubmit={onSubmit}
+    >
+      <div className="flex flex-col gap-4">
+        <label>
+          <span className="text-detail-l text-neutral-600">아이디</span>
+          <Input
+            text={id}
+            setText={setId}
+            placeholder="ID를 입력하세요."
+            required
+            maxLength="12"
+            pattern="^[\-\w]+$"
+          />
+        </label>
+        <label>
+          <span className="text-detail-l text-neutral-600">비밀번호</span>
+          <Input
+            text={password}
+            setText={setPassword}
+            type="password"
+            placeholder="비밀번호 입력하세요."
+            required
+            minLength="8"
+            maxLength="16"
+            pattern="^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$"
+          />
+        </label>
+      </div>
+      <div className="flex flex-col relative items-center">
+        <Button className="w-full" type="submit">
+          로그인
+        </Button>
+        <span className="absolute -bottom-4 text-detail-l text-red-400">
+          {errorMessage}
+        </span>
+      </div>
+    </form>
+  );
 }
 
 export default LoginSection;

--- a/src/adminPage/shared/auth/LoginSection.jsx
+++ b/src/adminPage/shared/auth/LoginSection.jsx
@@ -1,0 +1,29 @@
+import { useState } from "react";
+
+import Input from "@common/components/Input.jsx";
+import Button from "@common/components/Button.jsx";
+
+function LoginSection()
+{
+	const [id, setId] = useState("");
+	const [password, setPassword] = useState("");
+	function onSubmit(e)
+	{
+		e.preventDefault();
+	}
+	return <form className="group" onSubmit={onSubmit}>
+		<label>
+			아이디
+			<Input text={id} setText={setId} placeholder="ID를 입력하세요." required maxLength="12" pattern="^[\-\w]+$"/>
+		</label>
+		<label>
+			비밀번호
+			<Input text={password} setText={setPassword} type="password" placeholder="비밀번호 입력하세요." required
+			minLength="8" maxLength="16" pattern="^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$"
+			/>
+		</label>
+		<Button type="submit">로그인</Button>
+	</form>
+}
+
+export default LoginSection;

--- a/src/adminPage/shared/auth/LoginSection.jsx
+++ b/src/adminPage/shared/auth/LoginSection.jsx
@@ -11,17 +11,19 @@ function LoginSection()
 	{
 		e.preventDefault();
 	}
-	return <form className="group" onSubmit={onSubmit}>
-		<label>
-			아이디
-			<Input text={id} setText={setId} placeholder="ID를 입력하세요." required maxLength="12" pattern="^[\-\w]+$"/>
-		</label>
-		<label>
-			비밀번호
-			<Input text={password} setText={setPassword} type="password" placeholder="비밀번호 입력하세요." required
-			minLength="8" maxLength="16" pattern="^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$"
-			/>
-		</label>
+	return <form className="w-full h-full max-w-[32rem] max-h-[20rem] p-8 flex flex-col gap-8 bg-white shadow-md rounded-3xl group" onSubmit={onSubmit}>
+		<div className="flex flex-col gap-4">
+			<label>
+				<span className="text-detail-l text-neutral-600">아이디</span>
+				<Input text={id} setText={setId} placeholder="ID를 입력하세요." required maxLength="12" pattern="^[\-\w]+$"/>
+			</label>
+			<label>
+				<span className="text-detail-l text-neutral-600">비밀번호</span>
+				<Input text={password} setText={setPassword} type="password" placeholder="비밀번호 입력하세요." required
+				minLength="8" maxLength="16" pattern="^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,16}$"
+				/>
+			</label>
+		</div>
 		<Button type="submit">로그인</Button>
 	</form>
 }

--- a/src/adminPage/shared/auth/mock.js
+++ b/src/adminPage/shared/auth/mock.js
@@ -4,7 +4,7 @@ const handlers = [
   http.post("/api/v1/admin/auth/signin", async ({ request }) => {
     const { username, password } = await request.json();
     if (username !== "admin" && password !== "password1!") {
-      return HttpResponse.json({ return: false }, {status: 401});
+      return HttpResponse.json({ return: false }, { status: 401 });
     }
 
     return HttpResponse.json({ token: "test_token" });

--- a/src/adminPage/shared/auth/mock.js
+++ b/src/adminPage/shared/auth/mock.js
@@ -1,0 +1,14 @@
+import { http, HttpResponse } from "msw";
+
+const handlers = [
+  http.post("/api/v1/admin/auth/signin", async ({ request }) => {
+    const { username, password } = await request.json();
+    if (username !== "admin" && password !== "password1!") {
+      return HttpResponse.json({ return: false }, {status: 401});
+    }
+
+    return HttpResponse.json({ token: "test_token" });
+  }),
+];
+
+export default handlers;

--- a/src/adminPage/shared/auth/store.js
+++ b/src/adminPage/shared/auth/store.js
@@ -19,8 +19,7 @@ export function logout() {
 export function initLoginState() {
   tokenSaver.init(ADMIN_TOKEN_ID);
   const token = tokenSaver.get(ADMIN_TOKEN_ID);
-  if (token === null)
-    userStore.setState(() => ({ isLogin: false }));
+  if (token === null) userStore.setState(() => ({ isLogin: false }));
   else userStore.setState(() => ({ isLogin: true }));
 }
 

--- a/src/adminPage/shared/auth/store.js
+++ b/src/adminPage/shared/auth/store.js
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import tokenSaver from "@common/dataFetch/tokenSaver.js";
+import { ADMIN_TOKEN_ID } from "@common/constants.js";
+
+const userStore = create(() => ({
+  isLogin: false,
+}));
+
+export function login(token) {
+  tokenSaver.set(token);
+  userStore.setState(() => ({ isLogin: true }));
+}
+
+export function logout() {
+  tokenSaver.remove();
+  userStore.setState(() => ({ isLogin: false }));
+}
+
+export function initLoginState() {
+  tokenSaver.init(ADMIN_TOKEN_ID);
+  const token = tokenSaver.get(ADMIN_TOKEN_ID);
+  if (token === null)
+    userStore.setState(() => ({ isLogin: false }));
+  else userStore.setState(() => ({ isLogin: true }));
+}
+
+export default userStore;

--- a/src/adminPage/shared/components/Container.jsx
+++ b/src/adminPage/shared/components/Container.jsx
@@ -1,13 +1,14 @@
 import NavBar from "./NavBar.jsx";
 
-function Container({children})
-{
-	return <div className="w-full min-h-screen flex">
-		<NavBar />
-		<div className="w-full h-full min-h-screen flex-grow flex justify-center items-center">
-			{children}
-		</div>
-	</div>
+function Container({ children }) {
+  return (
+    <div className="w-full min-h-screen flex">
+      <NavBar />
+      <div className="w-full h-full min-h-screen flex-grow flex justify-center items-center">
+        {children}
+      </div>
+    </div>
+  );
 }
 
 export default Container;

--- a/src/adminPage/shared/components/Container.jsx
+++ b/src/adminPage/shared/components/Container.jsx
@@ -1,7 +1,9 @@
+import NavBar from "./NavBar.jsx";
+
 function Container({children})
 {
 	return <div className="w-full min-h-screen flex">
-		<div>내비게이션 바</div>
+		<NavBar />
 		<div className="w-full h-full min-h-screen flex-grow flex justify-center items-center">
 			{children}
 		</div>

--- a/src/adminPage/shared/components/Container.jsx
+++ b/src/adminPage/shared/components/Container.jsx
@@ -1,0 +1,11 @@
+function Container({children})
+{
+	return <div className="w-full min-h-screen flex">
+		<div>내비게이션 바</div>
+		<div className="w-full h-full min-h-screen flex-grow flex justify-center items-center">
+			{children}
+		</div>
+	</div>
+}
+
+export default Container;

--- a/src/adminPage/shared/components/NavBar.jsx
+++ b/src/adminPage/shared/components/NavBar.jsx
@@ -1,0 +1,16 @@
+import { Link } from "react-router-dom";
+
+function NavBar()
+{
+	return <nav className="w-36 h-screen sticky flex-shrink-0 top-0 bg-black flex flex-col items-center p-4 gap-4">
+		<p className="text-white py-4 border-b-2 border-white">관리자 페이지</p>
+		<ul className="w-full flex flex-col justify-center text-neutral-200">
+			<li className="w-full h-12 flex justify-center items-center"><Link >event</Link></li>
+			<li className="w-full h-12 flex justify-center items-center"><Link >기대평</Link></li>
+			<li className="w-full h-12 flex justify-center items-center"><button>LOGOUT</button></li>
+		</ul>
+	</nav>
+}
+
+
+export default NavBar;

--- a/src/adminPage/shared/components/NavBar.jsx
+++ b/src/adminPage/shared/components/NavBar.jsx
@@ -1,13 +1,13 @@
-import { Link } from "react-router-dom";
+import NavBarItem from "./NavBarItem.jsx";
 
 function NavBar()
 {
 	return <nav className="w-36 h-screen sticky flex-shrink-0 top-0 bg-black flex flex-col items-center p-4 gap-4">
 		<p className="text-white py-4 border-b-2 border-white">관리자 페이지</p>
-		<ul className="w-full flex flex-col justify-center text-neutral-200">
-			<li className="w-full h-12 flex justify-center items-center"><Link >event</Link></li>
-			<li className="w-full h-12 flex justify-center items-center"><Link >기대평</Link></li>
-			<li className="w-full h-12 flex justify-center items-center"><button>LOGOUT</button></li>
+		<ul className="w-full flex flex-col justify-center">
+			<NavBarItem to="/events">events</NavBarItem>
+			<NavBarItem to="/comments">기대평</NavBarItem>
+			<NavBarItem>LOGOUT</NavBarItem>
 		</ul>
 	</nav>
 }

--- a/src/adminPage/shared/components/NavBar.jsx
+++ b/src/adminPage/shared/components/NavBar.jsx
@@ -3,25 +3,28 @@ import { useNavigate } from "react-router-dom";
 import NavBarItem from "./NavBarItem.jsx";
 import useAuthStore, { logout } from "@admin/auth/store.js";
 
-function NavBar()
-{
-	const navigate = useNavigate();
-	const isLogin = useAuthStore( store=>store.isLogin );
-	function onLogoutClick()
-	{
-		logout();
-		navigate("/login");
-	}
+function NavBar() {
+  const navigate = useNavigate();
+  const isLogin = useAuthStore((store) => store.isLogin);
+  function onLogoutClick() {
+    logout();
+    navigate("/login");
+  }
 
-	return <nav className="w-36 h-screen sticky flex-shrink-0 top-0 bg-black flex flex-col items-center p-4 gap-4">
-		<p className="text-white py-4 border-b-2 border-white">관리자 페이지</p>
-		<ul className="w-full flex flex-col justify-center">
-			<NavBarItem disabled={!isLogin} to="/events">events</NavBarItem>
-			<NavBarItem disabled={!isLogin} to="/comments">기대평</NavBarItem>
-			{isLogin && <NavBarItem onClick={onLogoutClick}>LOGOUT</NavBarItem>}
-		</ul>
-	</nav>
+  return (
+    <nav className="w-36 h-screen sticky flex-shrink-0 top-0 bg-black flex flex-col items-center p-4 gap-4">
+      <p className="text-white py-4 border-b-2 border-white">관리자 페이지</p>
+      <ul className="w-full flex flex-col justify-center">
+        <NavBarItem disabled={!isLogin} to="/events">
+          events
+        </NavBarItem>
+        <NavBarItem disabled={!isLogin} to="/comments">
+          기대평
+        </NavBarItem>
+        {isLogin && <NavBarItem onClick={onLogoutClick}>LOGOUT</NavBarItem>}
+      </ul>
+    </nav>
+  );
 }
-
 
 export default NavBar;

--- a/src/adminPage/shared/components/NavBar.jsx
+++ b/src/adminPage/shared/components/NavBar.jsx
@@ -1,13 +1,24 @@
+import { useNavigate } from "react-router-dom";
+
 import NavBarItem from "./NavBarItem.jsx";
+import useAuthStore, { logout } from "@admin/auth/store.js";
 
 function NavBar()
 {
+	const navigate = useNavigate();
+	const isLogin = useAuthStore( store=>store.isLogin );
+	function onLogoutClick()
+	{
+		logout();
+		navigate("/login");
+	}
+
 	return <nav className="w-36 h-screen sticky flex-shrink-0 top-0 bg-black flex flex-col items-center p-4 gap-4">
 		<p className="text-white py-4 border-b-2 border-white">관리자 페이지</p>
 		<ul className="w-full flex flex-col justify-center">
-			<NavBarItem to="/events">events</NavBarItem>
-			<NavBarItem to="/comments">기대평</NavBarItem>
-			<NavBarItem>LOGOUT</NavBarItem>
+			<NavBarItem disabled={!isLogin} to="/events">events</NavBarItem>
+			<NavBarItem disabled={!isLogin} to="/comments">기대평</NavBarItem>
+			{isLogin && <NavBarItem onClick={onLogoutClick}>LOGOUT</NavBarItem>}
 		</ul>
 	</nav>
 }

--- a/src/adminPage/shared/components/NavBarItem.jsx
+++ b/src/adminPage/shared/components/NavBarItem.jsx
@@ -1,6 +1,6 @@
 import {NavLink} from "react-router-dom";
 
-function NavBarItem({to, onClick, children})
+function NavBarItem({to, onClick, disabled, children})
 {
 	const commonStyle = `w-full h-full flex justify-center items-center
 	hover:border-2 hover:border-white
@@ -9,11 +9,11 @@ function NavBarItem({to, onClick, children})
 	const commonTextStyle = `text-neutral-200 hover:text-white active:text-neutral-400 invalid:text-neutral-600`;
 
 	const navLink = <NavLink to={to} 
-		className={ ({isActive})=>`${commonStyle} ${isActive ? "text-blue-400" : commonTextStyle}` }>
+		className={ ({isActive})=>`${commonStyle} ${disabled ? "pointer-events-none text-neutral-600": ""} ${isActive ? "text-blue-400" : commonTextStyle}` }>
 		{children}
 	</NavLink>;
 
-	const button = <button onClick={onClick} className={`${commonStyle} ${commonTextStyle}`}>{children}</button>;
+	const button = <button onClick={onClick} disabled={disabled} className={`${commonStyle} ${commonTextStyle}`}>{children}</button>;
 
 	return <li className="w-full h-12 flex justify-center items-center">
 		{to ? navLink : button}

--- a/src/adminPage/shared/components/NavBarItem.jsx
+++ b/src/adminPage/shared/components/NavBarItem.jsx
@@ -1,23 +1,38 @@
-import {NavLink} from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
-function NavBarItem({to, onClick, disabled, children})
-{
-	const commonStyle = `w-full h-full flex justify-center items-center
+function NavBarItem({ to, onClick, disabled, children }) {
+  const commonStyle = `w-full h-full flex justify-center items-center
 	hover:border-2 hover:border-white
 	active:border-2 active:border-neutral-400`;
 
-	const commonTextStyle = `text-neutral-200 hover:text-white active:text-neutral-400 invalid:text-neutral-600`;
+  const commonTextStyle = `text-neutral-200 hover:text-white active:text-neutral-400 invalid:text-neutral-600`;
 
-	const navLink = <NavLink to={to} 
-		className={ ({isActive})=>`${commonStyle} ${disabled ? "pointer-events-none text-neutral-600": ""} ${isActive ? "text-blue-400" : commonTextStyle}` }>
-		{children}
-	</NavLink>;
+  const navLink = (
+    <NavLink
+      to={to}
+      className={({ isActive }) =>
+        `${commonStyle} ${disabled ? "pointer-events-none text-neutral-600" : ""} ${isActive ? "text-blue-400" : commonTextStyle}`
+      }
+    >
+      {children}
+    </NavLink>
+  );
 
-	const button = <button onClick={onClick} disabled={disabled} className={`${commonStyle} ${commonTextStyle}`}>{children}</button>;
+  const button = (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={`${commonStyle} ${commonTextStyle}`}
+    >
+      {children}
+    </button>
+  );
 
-	return <li className="w-full h-12 flex justify-center items-center">
-		{to ? navLink : button}
-	</li>
+  return (
+    <li className="w-full h-12 flex justify-center items-center">
+      {to ? navLink : button}
+    </li>
+  );
 }
 
 export default NavBarItem;

--- a/src/adminPage/shared/components/NavBarItem.jsx
+++ b/src/adminPage/shared/components/NavBarItem.jsx
@@ -1,0 +1,23 @@
+import {NavLink} from "react-router-dom";
+
+function NavBarItem({to, onClick, children})
+{
+	const commonStyle = `w-full h-full flex justify-center items-center
+	hover:border-2 hover:border-white
+	active:border-2 active:border-neutral-400`;
+
+	const commonTextStyle = `text-neutral-200 hover:text-white active:text-neutral-400 invalid:text-neutral-600`;
+
+	const navLink = <NavLink to={to} 
+		className={ ({isActive})=>`${commonStyle} ${isActive ? "text-blue-400" : commonTextStyle}` }>
+		{children}
+	</NavLink>;
+
+	const button = <button onClick={onClick} className={`${commonStyle} ${commonTextStyle}`}>{children}</button>;
+
+	return <li className="w-full h-12 flex justify-center items-center">
+		{to ? navLink : button}
+	</li>
+}
+
+export default NavBarItem;

--- a/src/common/dataFetch/fetchServer.js
+++ b/src/common/dataFetch/fetchServer.js
@@ -15,7 +15,9 @@ class ServerCloseError extends Error {
   }
 }
 
-function fetchServer(url, options = {}) {
+// fetchServer의 옵션을 생성합니다.
+function createFetchOptions(options = {})
+{
   // 기본적으로 옵션을 그대로 가져오지만, body가 존재하고 header.content-type을 설정하지 않는다면
   // json으로 간주하여 option을 생성합니다.
   const fetchOptions = { ...options };
@@ -40,23 +42,70 @@ function fetchServer(url, options = {}) {
     };
   }
 
-  const promise = fetch(url, fetchOptions)
-    .then((e) => {
-      if (e.status >= 400 && e.status <= 599) throw new HTTPError(e);
-      return e;
-    })
-    .then((e) => e.json())
-    .catch(async (e) => {
-      if (e instanceof HTTPError) {
-        e.data = await e.response.json();
-      }
-      if (e instanceof TypeError && e.message === "Failed to fetch") {
-        throw new ServerCloseError();
-      }
-      throw e;
-    });
+  return fetchOptions;
+}
+
+// 기본적인 fetchServer의 동작을 수행합니다.
+async function fetchServerBase(url, options = {}) {
+  try {
+    const response = await fetch(url, createFetchOptions(options));
+    if (response.status >= 400 && response.status <= 599) throw new HTTPError(response);
+    return await response.json();
+  }
+  catch( e )
+  {
+    if( e instanceof HTTPError ) {
+      e.data = await e.response.json();
+    }
+    if( e instanceof TypeError && e.message === "Failed to fetch" ) {
+      throw new ServerCloseError();
+    }
+    throw e;
+  }
+}
+
+// fetchServer의 동작을 수행한 뒤, 미들웨어를 차례대로 실행시킵니다.
+async function fetchServer(url, options = {}) {
+  let promise = fetchServerBase(url, options);
+  if(fetchServer.middlewares.size === 0) return promise;
+
+  let shouldProgress = false;
+  const next = ()=>shouldProgress = true;
+
+  for(let middleware of fetchServer.middlewares)
+  {
+    try {
+      const value = await promise;
+      promise = (async () => {
+        const result = await middleware({value}, next);
+        return result ?? value;
+      })();
+      if(!shouldProgress) return value;
+    }
+    catch(error) {
+      promise = (async () => {
+        const result = await middleware({error}, next);
+        if(result !== undefined && result !== null) return result;
+        throw error;
+      })();
+      if(!shouldProgress) throw error;
+    }
+
+    shouldProgress = false;
+  }
 
   return promise;
+}
+
+// 미들웨어를 등록시키고 제거합니다.
+fetchServer.middlewares = new Set();
+fetchServer.use = function(middleware)
+{
+  fetchServer.middlewares.add( middleware );
+}
+fetchServer.unuse = function(middleware)
+{
+  fetchServer.middlewares.delete( middleware );
 }
 
 function handleError(errorDescriptor) {

--- a/src/common/dataFetch/fetchServer.js
+++ b/src/common/dataFetch/fetchServer.js
@@ -16,8 +16,7 @@ class ServerCloseError extends Error {
 }
 
 // fetchServer의 옵션을 생성합니다.
-function createFetchOptions(options = {})
-{
+function createFetchOptions(options = {}) {
   // 기본적으로 옵션을 그대로 가져오지만, body가 존재하고 header.content-type을 설정하지 않는다면
   // json으로 간주하여 option을 생성합니다.
   const fetchOptions = { ...options };
@@ -49,15 +48,14 @@ function createFetchOptions(options = {})
 async function fetchServerBase(url, options = {}) {
   try {
     const response = await fetch(url, createFetchOptions(options));
-    if (response.status >= 400 && response.status <= 599) throw new HTTPError(response);
+    if (response.status >= 400 && response.status <= 599)
+      throw new HTTPError(response);
     return await response.json();
-  }
-  catch( e )
-  {
-    if( e instanceof HTTPError ) {
+  } catch (e) {
+    if (e instanceof HTTPError) {
       e.data = await e.response.json();
     }
-    if( e instanceof TypeError && e.message === "Failed to fetch" ) {
+    if (e instanceof TypeError && e.message === "Failed to fetch") {
       throw new ServerCloseError();
     }
     throw e;
@@ -67,28 +65,26 @@ async function fetchServerBase(url, options = {}) {
 // fetchServer의 동작을 수행한 뒤, 미들웨어를 차례대로 실행시킵니다.
 async function fetchServer(url, options = {}) {
   let promise = fetchServerBase(url, options);
-  if(fetchServer.middlewares.size === 0) return promise;
+  if (fetchServer.middlewares.size === 0) return promise;
 
   let shouldProgress = false;
-  const next = ()=>shouldProgress = true;
+  const next = () => (shouldProgress = true);
 
-  for(let middleware of fetchServer.middlewares)
-  {
+  for (let middleware of fetchServer.middlewares) {
     try {
       const value = await promise;
       promise = (async () => {
-        const result = await middleware({value}, next);
+        const result = await middleware({ value }, next);
         return result ?? value;
       })();
-      if(!shouldProgress) return value;
-    }
-    catch(error) {
+      if (!shouldProgress) return value;
+    } catch (error) {
       promise = (async () => {
-        const result = await middleware({error}, next);
-        if(result !== undefined && result !== null) return result;
+        const result = await middleware({ error }, next);
+        if (result !== undefined && result !== null) return result;
         throw error;
       })();
-      if(!shouldProgress) throw error;
+      if (!shouldProgress) throw error;
     }
 
     shouldProgress = false;
@@ -99,14 +95,12 @@ async function fetchServer(url, options = {}) {
 
 // 미들웨어를 등록시키고 제거합니다.
 fetchServer.middlewares = new Set();
-fetchServer.use = function(middleware)
-{
-  fetchServer.middlewares.add( middleware );
-}
-fetchServer.unuse = function(middleware)
-{
-  fetchServer.middlewares.delete( middleware );
-}
+fetchServer.use = function (middleware) {
+  fetchServer.middlewares.add(middleware);
+};
+fetchServer.unuse = function (middleware) {
+  fetchServer.middlewares.delete(middleware);
+};
 
 function handleError(errorDescriptor) {
   return (error) => {

--- a/src/common/dataFetch/initLogoutMiddleware.js
+++ b/src/common/dataFetch/initLogoutMiddleware.js
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { fetchServer, HTTPError } from "@common/dataFetch/fetchServer.js";
+
+export default function useLogoutMiddleware(logout) {
+  useEffect( ()=>{
+    function middleware( {error}, next ) {
+      if(error instanceof HTTPError && error.status === 401) {
+        logout();
+      }
+      next();
+    }
+
+    fetchServer.use( middleware );
+    return ()=>fetchServer.unuse( middleware );
+  }, [logout] );
+}

--- a/src/common/dataFetch/initLogoutMiddleware.js
+++ b/src/common/dataFetch/initLogoutMiddleware.js
@@ -2,15 +2,15 @@ import { useEffect } from "react";
 import { fetchServer, HTTPError } from "@common/dataFetch/fetchServer.js";
 
 export default function useLogoutMiddleware(logout) {
-  useEffect( ()=>{
-    function middleware( {error}, next ) {
-      if(error instanceof HTTPError && error.status === 401) {
+  useEffect(() => {
+    function middleware({ error }, next) {
+      if (error instanceof HTTPError && error.status === 401) {
         logout();
       }
       next();
     }
 
-    fetchServer.use( middleware );
-    return ()=>fetchServer.unuse( middleware );
-  }, [logout] );
+    fetchServer.use(middleware);
+    return () => fetchServer.unuse(middleware);
+  }, [logout]);
 }

--- a/src/mainPage/App.jsx
+++ b/src/mainPage/App.jsx
@@ -11,7 +11,8 @@ import QnA from "./features/qna";
 import Footer from "./features/footer";
 
 import Modal from "@common/modal/modal.jsx";
-import { initLoginState } from "@main/auth/store.js";
+import { initLoginState, logout } from "@main/auth/store.js";
+import useLogoutMiddleware from "@common/dataFetch/initLogoutMiddleware";
 
 function App() {
   useEffect(() => {
@@ -19,6 +20,7 @@ function App() {
     history.scrollRestoration = "manual";
     initLoginState();
   }, []);
+  useLogoutMiddleware(logout);
 
   return (
     <>

--- a/src/mainPage/features/fcfs/mock.js
+++ b/src/mainPage/features/fcfs/mock.js
@@ -31,6 +31,8 @@ const handlers = [
 
     const token = request.headers.get("authorization");
     if (token === null) return HttpResponse.json(false, { status: 401 });
+    if (token !== "Bearer test_token")
+      return HttpResponse.json(false, { status: 401 });
 
     if (typeof eventAnswer !== "number")
       return HttpResponse.json(false, { status: 400 });


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #25 
- #27 

# 📝 작업 내용

> 어드민 페이지의 로그인 기능을 추가했습니다.
- 로그인되었을 떄 상태에 따라 라우터도 설정해 뒀습니다.
- GNB도 추가했습니다.
  - events : 이벤트 관리 페이지
  - comments : 기대평 관리 페이지

> fetchServer의 미들웨어 기능을 추가했고, 로그아웃 미들웨어를 추가했습니다.
이제 401 에러를 반환하면 자동으로 로그아웃이 됩니다.