### PR TITLE
[feat, chore] 자잘한 것들 수정 및 성능 개선

### DIFF
--- a/build.js
+++ b/build.js
@@ -86,8 +86,9 @@ async function injectSSGToHtml(mode) {
 			await mkdir(dir, { recursive: true });
 			await writeFile(absolutePath, html);
 			console.log(`pre-rendered : ${path}`);
-		} catch {
+		} catch(e) {
 			console.log(`pre-rendered failed : ${path}`);
+			console.error(e);
 		}
 	} );
 	await Promise.allSettled(promises);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "awesome-orange-project",
       "version": "0.5.0",
       "dependencies": {
+        "jwt-decode": "^4.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-lottie-player": "^2.1.0",
@@ -4600,6 +4601,15 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "preview-admin": "vite preview --outDir dist/admin"
   },
   "dependencies": {
+    "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-lottie-player": "^2.1.0",

--- a/src/adminPage/features/eventEdit/businessLogic/FcfsData.js
+++ b/src/adminPage/features/eventEdit/businessLogic/FcfsData.js
@@ -94,6 +94,16 @@ function verifyItems(map, { startTime, endTime, prevSnapshot = new Map() }) {
   return result;
 }
 
+function hasDuplicatedDate(newDate, map)
+{
+  if(newDate === undefined) return true;
+  if(newDate === null) return false;
+  const dateSet = new Set([...map.values()].map( ({date})=>date?.valueOf() ?? null ));
+
+  if(dateSet.has(newDate.valueOf())) return true;
+  return false;
+}
+
 function getDefaultFcfsArray(
   startTime,
   endTime,
@@ -194,12 +204,17 @@ class FcfsData {
   modify(key, data, { startTime, endTime }) {
     const newData = new FcfsData(this.map);
     const oldItem = newData.map.get(key);
+
     const verified = verifyItem(
-      { ...oldItem, ...data },
+      {...oldItem, ...data},
       { startTime, endTime, prevSnapshot: oldItem },
     );
     if (verified === null) newData.map.delete(key);
-    else newData.map.set(key, verified);
+    else {
+      if(hasDuplicatedDate(verified.date, this.map)) verified.date = oldItem.date;
+
+      newData.map.set(key, verified);
+    }
     return newData;
   }
   modifyAll(data, { startTime, endTime }) {

--- a/src/adminPage/features/eventEdit/businessLogic/FcfsData.js
+++ b/src/adminPage/features/eventEdit/businessLogic/FcfsData.js
@@ -94,13 +94,12 @@ function verifyItems(map, { startTime, endTime, prevSnapshot = new Map() }) {
   return result;
 }
 
-function hasDuplicatedDate(newDate, map)
-{
-  if(newDate === undefined) return true;
-  if(newDate === null) return false;
-  const dateSet = new Set([...map.values()].map( ({date})=>date?.valueOf() ?? null ));
+function hasDuplicatedDate(newDate, map) {
+  if (newDate === undefined) return true;
+  if (newDate === null) return false;
+  const dateSet = new Set([...map.values()].map(({ date }) => date?.valueOf() ?? null));
 
-  if(dateSet.has(newDate.valueOf())) return true;
+  if (dateSet.has(newDate.valueOf())) return true;
   return false;
 }
 
@@ -206,12 +205,12 @@ class FcfsData {
     const oldItem = newData.map.get(key);
 
     const verified = verifyItem(
-      {...oldItem, ...data},
+      { ...oldItem, ...data },
       { startTime, endTime, prevSnapshot: oldItem },
     );
     if (verified === null) newData.map.delete(key);
     else {
-      if(hasDuplicatedDate(verified.date, this.map)) verified.date = oldItem.date;
+      if (hasDuplicatedDate(verified.date, this.map)) verified.date = oldItem.date;
 
       newData.map.set(key, verified);
     }

--- a/src/mainPage/App.jsx
+++ b/src/mainPage/App.jsx
@@ -11,14 +11,14 @@ import QnA from "./features/qna";
 import Footer from "./features/footer";
 
 import Modal from "@common/modal/modal.jsx";
-import { initLoginState, logout } from "@main/auth/store.js";
+import { logout } from "@main/auth/store.js";
 import useLogoutMiddleware from "@common/dataFetch/initLogoutMiddleware";
 
 function App() {
   useEffect(() => {
     window.scrollTo(0, 0);
     history.scrollRestoration = "manual";
-    initLoginState();
+    //initLoginState();
   }, []);
   useLogoutMiddleware(logout);
 

--- a/src/mainPage/features/comment/commentForm/index.jsx
+++ b/src/mainPage/features/comment/commentForm/index.jsx
@@ -33,7 +33,7 @@ function CommentForm() {
         setButtonFetchState(submitted ? "disabled" : "enabled");
       })
       .catch((e) => {
-        if(e.status === 401) {
+        if (e.status === 401) {
           setButtonFetchState("enabled");
           return;
         }

--- a/src/mainPage/features/comment/commentForm/index.jsx
+++ b/src/mainPage/features/comment/commentForm/index.jsx
@@ -32,6 +32,10 @@ function CommentForm() {
         setButtonFetchState(submitted ? "disabled" : "enabled");
       })
       .catch((e) => {
+        if(e.status === 401) {
+          setButtonFetchState("enabled");
+          return;
+        }
         console.error(e);
         setButtonFetchState("error");
       })

--- a/src/mainPage/features/comment/commentForm/index.jsx
+++ b/src/mainPage/features/comment/commentForm/index.jsx
@@ -13,6 +13,7 @@ import openModal from "@common/modal/openModal.js";
 const submitCommentErrorHandle = {
   400: "negative",
   401: "unauthorized",
+  404: "no_participated",
   409: "하루에 1번만 기대평을 등록할 수 있습니다.",
   offline: "offline",
 };
@@ -74,6 +75,7 @@ function CommentForm() {
         case submitCommentErrorHandle[400]:
           return openModal(negativeModal);
         case submitCommentErrorHandle[401]:
+        case submitCommentErrorHandle[404]:
           return openModal(noUserModal);
         case submitCommentErrorHandle["offline"]:
           return openModal(noServerModal);

--- a/src/mainPage/features/comment/mock.js
+++ b/src/mainPage/features/comment/mock.js
@@ -18,7 +18,7 @@ const handlers = [
   http.get("/api/v1/comment/info", ({ request }) => {
     const token = request.headers.get("authorization");
 
-    if (token === null) return HttpResponse.json({ submitted: false }, {status: 401});
+    if (token === null) return HttpResponse.json({ submitted: false }, { status: 401 });
     return HttpResponse.json({ submitted: false });
   }),
   http.get("/api/v1/comment/:eventFrameId", () => {

--- a/src/mainPage/features/comment/mock.js
+++ b/src/mainPage/features/comment/mock.js
@@ -18,7 +18,7 @@ const handlers = [
   http.get("/api/v1/comment/info", ({ request }) => {
     const token = request.headers.get("authorization");
 
-    if (token === null) return HttpResponse.json({ submitted: false });
+    if (token === null) return HttpResponse.json({ submitted: false }, {status: 401});
     return HttpResponse.json({ submitted: false });
   }),
   http.get("/api/v1/comment/:eventFrameId", () => {

--- a/src/mainPage/features/detailInformation/DetailItem.jsx
+++ b/src/mainPage/features/detailInformation/DetailItem.jsx
@@ -7,6 +7,7 @@ function DetailItem({ img, title, description }) {
         className="absolute w-full h-full -z-10 top-0 left-0 object-cover"
         width="1920"
         height="1080"
+        loading="lazy"
       />
       <div className="text-white w-full flex flex-col gap-4">
         <h3 className="whitespace-pre-wrap text-title-s font-bold md:text-title-m lg:text-title-l">

--- a/src/mainPage/features/fcfs/cardGame/Card.jsx
+++ b/src/mainPage/features/fcfs/cardGame/Card.jsx
@@ -46,6 +46,7 @@ function Card({ index, locked, isFlipped, setFlipped, setGlobalLock, getCardAnsw
           srcSet={`${hidden1x} 1x, ${hidden2x} 2x`}
           alt="hidden"
           draggable="false"
+          loading="lazy"
         />
         <img
           className={`${cardFaceBaseStyle} ${style.back}`}
@@ -53,6 +54,7 @@ function Card({ index, locked, isFlipped, setFlipped, setGlobalLock, getCardAnsw
           srcSet={`${answer1x} 1x, ${answer2x} 2x`}
           alt={isCorrect ? "축하합니다, 당첨입니다!" : "아쉽게도 정답이 아니네요!"}
           draggable="false"
+          loading="lazy"
         />
       </div>
     </button>

--- a/src/mainPage/features/fcfs/description/DateEventPrize.jsx
+++ b/src/mainPage/features/fcfs/description/DateEventPrize.jsx
@@ -14,7 +14,7 @@ function DateEventPrize({ date, title, capacity, image }) {
 
   return (
     <div className={`flex gap-6 p-6 ${bgColor} ${opacity}`}>
-      <img src={image} alt={title} width="130" height="88" />
+      <img src={image} alt={title} width="130" height="88" loading="lazy" />
       <div className="font-bold">
         <p
           className={`text-body-m ${dateStatus === "ended" ? "text-neutral-500" : "text-blue-400"}`}

--- a/src/mainPage/features/fcfs/mock.js
+++ b/src/mainPage/features/fcfs/mock.js
@@ -16,11 +16,11 @@ const handlers = [
   }),
   http.get("/api/v1/event/fcfs/:eventFrameId/participated", async ({ request }) => {
     const token = request.headers.get("authorization");
-    if (token === null) return HttpResponse.json({ answerResult: false, winner: false });
+    if (token === null) return HttpResponse.json(false);
 
     //await delay(10000);
 
-    return HttpResponse.json({ answerResult: false, winner: false });
+    return HttpResponse.json(false);
   }),
   http.post("/api/v1/event/fcfs/:eventFrameId", async ({ request }) => {
     const { eventAnswer } = await request.json();

--- a/src/mainPage/features/header/Hamburger/Button.jsx
+++ b/src/mainPage/features/header/Hamburger/Button.jsx
@@ -5,12 +5,12 @@ function HamburgerButton({children})
 {
 	const [opened, setOpened] = useState(false);
 	return <>
-		<button className="flex md:hidden justify-center items-center size-8 z-10" aria-label="open-menu" onClick={ ()=>setOpened((state)=>!state) }>
+		<button className="flex md:hidden justify-center items-center size-6 z-10" aria-label="open-menu" onClick={ ()=>setOpened((state)=>!state) }>
 			<div className={style.hamburger} data-opened={opened} >
 				<div></div>
 			</div>
 		</button>
-		<div className="fixed -z-10 w-full top-0 left-0  bg-white flex md:hidden flex-col justify-center items-center gap-2">
+		<div className="fixed -z-10 w-full top-0 left-0 bg-white flex md:hidden flex-col justify-center items-center gap-2">
 			<div className="w-full mt-16 shadow-xl">{opened && children}</div>
 		</div>
 	</>

--- a/src/mainPage/features/header/Hamburger/Button.jsx
+++ b/src/mainPage/features/header/Hamburger/Button.jsx
@@ -1,0 +1,17 @@
+import { useState } from "react";
+import style from "./style.module.css";
+
+function HamburgerButton({children})
+{
+	const [opened, setOpened] = useState(false);
+	return <>
+		<button className="flex md:hidden justify-center items-center size-8 z-10" aria-label="open-menu" onClick={ ()=>setOpened((state)=>!state) }>
+			<div className={style.hamburger} data-opened={opened} >
+				<div></div>
+			</div>
+		</button>
+		<div className="fixed -z-10 w-full top-0 left-0 bg-white flex md:hidden flex-col justify-center items-center gap-2">{opened && children}</div>
+	</>
+}
+
+export default HamburgerButton;

--- a/src/mainPage/features/header/Hamburger/Button.jsx
+++ b/src/mainPage/features/header/Hamburger/Button.jsx
@@ -1,19 +1,24 @@
 import { useState } from "react";
 import style from "./style.module.css";
 
-function HamburgerButton({children})
-{
-	const [opened, setOpened] = useState(false);
-	return <>
-		<button className="flex md:hidden justify-center items-center size-6 z-10" aria-label="open-menu" onClick={ ()=>setOpened((state)=>!state) }>
-			<div className={style.hamburger} data-opened={opened} >
-				<div></div>
-			</div>
-		</button>
-		<div className="fixed -z-10 w-full top-0 left-0 bg-white flex md:hidden flex-col justify-center items-center gap-2">
-			<div className="w-full mt-16 shadow-xl">{opened && children}</div>
-		</div>
-	</>
+function HamburgerButton({ children }) {
+  const [opened, setOpened] = useState(false);
+  return (
+    <>
+      <button
+        className="flex md:hidden justify-center items-center size-6 z-10"
+        aria-label="open-menu"
+        onClick={() => setOpened((state) => !state)}
+      >
+        <div className={style.hamburger} data-opened={opened}>
+          <div></div>
+        </div>
+      </button>
+      <div className="fixed -z-10 w-full top-0 left-0 bg-white flex md:hidden flex-col justify-center items-center gap-2">
+        <div className="w-full mt-16 shadow-xl">{opened && children}</div>
+      </div>
+    </>
+  );
 }
 
 export default HamburgerButton;

--- a/src/mainPage/features/header/Hamburger/Button.jsx
+++ b/src/mainPage/features/header/Hamburger/Button.jsx
@@ -10,7 +10,9 @@ function HamburgerButton({children})
 				<div></div>
 			</div>
 		</button>
-		<div className="fixed -z-10 w-full top-0 left-0 bg-white flex md:hidden flex-col justify-center items-center gap-2">{opened && children}</div>
+		<div className="fixed -z-10 w-full top-0 left-0  bg-white flex md:hidden flex-col justify-center items-center gap-2">
+			<div className="w-full mt-16 shadow-xl">{opened && children}</div>
+		</div>
 	</>
 }
 

--- a/src/mainPage/features/header/Hamburger/style.module.css
+++ b/src/mainPage/features/header/Hamburger/style.module.css
@@ -1,52 +1,53 @@
 .hamburger {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	position: relative;
-	width: 24px;
-	height: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  width: 24px;
+  height: 20px;
 }
 
-.hamburger > div, .hamburger > div::before, .hamburger > div::after{
-	width: 100%;
-	height: 2px;
-	box-sizing: border-box;
-	background-color: currentColor;
-	transition: all 0.3s;
+.hamburger > div,
+.hamburger > div::before,
+.hamburger > div::after {
+  width: 100%;
+  height: 2px;
+  box-sizing: border-box;
+  background-color: currentColor;
+  transition: all 0.3s;
 }
 
-.hamburger > div{
-	position: absolute;
-	border-color: #24adaf;
+.hamburger > div {
+  position: absolute;
+  border-color: #24adaf;
 }
 
-.hamburger > div::before
-{
-	content: "";
-	display: block;
-	position: absolute;
-	top:0;
-	left:0;
-	transform: translateY(-10px);
+.hamburger > div::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-10px);
 }
 
-.hamburger > div::after{
-	content: "";
-	display: block;
-	position: absolute;
-	top:0;
-	left:0;
-	transform: translateY(10px);
+.hamburger > div::after {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(10px);
 }
 
 .hamburger[data-opened="true"] > div {
-	transform: rotate(135deg);
+  transform: rotate(135deg);
 }
 
 .hamburger[data-opened="true"] > div::before {
-	transform: translateY(0px) rotate(180deg);
+  transform: translateY(0px) rotate(180deg);
 }
 
 .hamburger[data-opened="true"] > div::after {
-	transform: translateY(-0px) rotate(-270deg);
+  transform: translateY(-0px) rotate(-270deg);
 }

--- a/src/mainPage/features/header/Hamburger/style.module.css
+++ b/src/mainPage/features/header/Hamburger/style.module.css
@@ -1,0 +1,52 @@
+.hamburger {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	position: relative;
+	width: 24px;
+	height: 20px;
+}
+
+.hamburger > div, .hamburger > div::before, .hamburger > div::after{
+	width: 100%;
+	height: 2px;
+	box-sizing: border-box;
+	background-color: currentColor;
+	transition: all 0.3s;
+}
+
+.hamburger > div{
+	position: absolute;
+	border-color: #24adaf;
+}
+
+.hamburger > div::before
+{
+	content: "";
+	display: block;
+	position: absolute;
+	top:0;
+	left:0;
+	transform: translateY(-10px);
+}
+
+.hamburger > div::after{
+	content: "";
+	display: block;
+	position: absolute;
+	top:0;
+	left:0;
+	transform: translateY(10px);
+}
+
+.hamburger[data-opened="true"] > div {
+	transform: rotate(135deg);
+}
+
+.hamburger[data-opened="true"] > div::before {
+	transform: translateY(0px) rotate(180deg);
+}
+
+.hamburger[data-opened="true"] > div::after {
+	transform: translateY(-0px) rotate(-270deg);
+}

--- a/src/mainPage/features/header/index.jsx
+++ b/src/mainPage/features/header/index.jsx
@@ -1,6 +1,7 @@
 import scrollTo from "@main/scroll/scrollTo";
 import { useSectionStore } from "@main/scroll/store";
 import AuthButtonSection from "./AuthButtonSection.jsx";
+import HamburgerButton from "./Hamburger/Button.jsx";
 
 import style from "./index.module.css";
 
@@ -52,6 +53,20 @@ export default function Header() {
       <div className="hidden md:flex">
         <AuthButtonSection />
       </div>
+      <HamburgerButton>
+        <ul className="h-full gap-4 lg:gap-8 text-body-s lg:text-body-m relative">
+          {scrollSectionList.map((scrollSection, index) => (
+            <li
+              key={index}
+              onClick={() => onClickScrollSection(index + 1)}
+              className={`flex justify-center items-center w-20 lg:w-24 cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
+            >
+              {scrollSection}
+            </li>
+          ))}
+        </ul>
+        <AuthButtonSection />
+      </HamburgerButton>
     </nav>
   );
 }

--- a/src/mainPage/features/header/index.jsx
+++ b/src/mainPage/features/header/index.jsx
@@ -54,18 +54,20 @@ export default function Header() {
         <AuthButtonSection />
       </div>
       <HamburgerButton>
-        <ul className="h-full gap-4 lg:gap-8 text-body-s lg:text-body-m relative">
-          {scrollSectionList.map((scrollSection, index) => (
-            <li
-              key={index}
-              onClick={() => onClickScrollSection(index + 1)}
-              className={`flex justify-center items-center w-20 lg:w-24 cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
-            >
-              {scrollSection}
-            </li>
-          ))}
-        </ul>
-        <AuthButtonSection />
+        <div className="w-full px-6 py-2 flex flex-col sm:flex-row gap-4 justify-between items-center">
+          <ul className="flex flex-col sm:flex-row gap-4 lg:gap-8 text-body-s lg:text-body-m relative">
+            {scrollSectionList.map((scrollSection, index) => (
+              <li
+                key={index}
+                onClick={() => onClickScrollSection(index + 1)}
+                className={`flex justify-center items-center w-20 lg:w-24 cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
+              >
+                {scrollSection}
+              </li>
+            ))}
+          </ul>
+          <AuthButtonSection />
+        </div>
       </HamburgerButton>
     </nav>
   );

--- a/src/mainPage/features/interactions/description/GiftDetail.jsx
+++ b/src/mainPage/features/interactions/description/GiftDetail.jsx
@@ -5,7 +5,7 @@ export default function GiftDetail({ contentList }) {
     <div className="flex flex-col font-bold">
       {contentList.map((content, index) => (
         <div key={index} className="bg-neutral-900 p-6 mb-5 flex z-0 relative">
-          <img src={content.src} alt="경품" width="130" height="89" loading="lazy"  />
+          <img src={content.src} alt="경품" width="130" height="89" loading="lazy" />
 
           <div className="pl-8 flex flex-col">
             <span className="text-body-m sm:text-body-l text-white">

--- a/src/mainPage/features/interactions/description/GiftDetail.jsx
+++ b/src/mainPage/features/interactions/description/GiftDetail.jsx
@@ -5,7 +5,7 @@ export default function GiftDetail({ contentList }) {
     <div className="flex flex-col font-bold">
       {contentList.map((content, index) => (
         <div key={index} className="bg-neutral-900 p-6 mb-5 flex z-0 relative">
-          <img src={content.src} alt="경품" />
+          <img src={content.src} alt="경품" width="130" height="89" loading="lazy"  />
 
           <div className="pl-8 flex flex-col">
             <span className="text-body-m sm:text-body-l text-white">

--- a/src/mainPage/features/interactions/description/InteractionSlide.jsx
+++ b/src/mainPage/features/interactions/description/InteractionSlide.jsx
@@ -60,11 +60,13 @@ export default function InteractionSlide({ interactionDesc, index, isCurrent, sl
       <img
         src={inactiveImgPath}
         alt="inactiveImage"
+        loading="lazy"
         className={`-z-10 absolute transition ease-in-out duration-200 ${isCurrent ? "opacity-0" : "opacity-100"}`}
       />
       <img
         src={activeImgPath}
         alt="activeImage"
+        loading="lazy"
         className={`-z-10 absolute transition ease-in-out duration-200 ${isCurrent ? "opacity-100" : "opacity-30 sm:opacity-0"}`}
       />
     </div>

--- a/src/mainPage/features/simpleInformation/contentSection.jsx
+++ b/src/mainPage/features/simpleInformation/contentSection.jsx
@@ -45,7 +45,7 @@ export default function ContentSection({ content }) {
       onAnimationEnd={() => setIsHighlighted(true)}
       className={`${isVisible ? style.fadeIn : "opacity-0"} z-0 flex flex-col font-bold`}
     >
-      <img src={content.src} alt={content.title} width="1200" height="456" className="w-full" />
+      <img src={content.src} alt={content.title} width="1200" height="456" className="w-full" loading="lazy" />
 
       <span className="pt-10 text-body-m sm:text-body-l text-neutral-800">{content.title}</span>
 

--- a/src/mainPage/features/simpleInformation/contentSection.jsx
+++ b/src/mainPage/features/simpleInformation/contentSection.jsx
@@ -45,7 +45,14 @@ export default function ContentSection({ content }) {
       onAnimationEnd={() => setIsHighlighted(true)}
       className={`${isVisible ? style.fadeIn : "opacity-0"} z-0 flex flex-col font-bold`}
     >
-      <img src={content.src} alt={content.title} width="1200" height="456" className="w-full" loading="lazy" />
+      <img
+        src={content.src}
+        alt={content.title}
+        width="1200"
+        height="456"
+        className="w-full"
+        loading="lazy"
+      />
 
       <span className="pt-10 text-body-m sm:text-body-l text-neutral-800">{content.title}</span>
 

--- a/src/mainPage/shared/auth/mock.js
+++ b/src/mainPage/shared/auth/mock.js
@@ -4,7 +4,8 @@ function isValidInput(name, phoneNumber) {
   return name.length >= 2 && phoneNumber.length < 12 && phoneNumber.startsWith("01");
 }
 
-const token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZWFtLW9yYW5nZSIsImlhdCI6MTcyNDA0NDc5MCwiZXhwIjoxNzI0MDQ4MzkwLCJzdWIiOiJldmVudFVzZXIiLCJ1c2VyTmFtZSI6Iuq5gOyCoeu6qSIsInVzZXJJZCI6ImtpbXBpcHB5YXAiLCJyb2xlIjoiZXZlbnRfdXNlciJ9.m5m_PkwmYz5Mt-kjn28435bQtwgph3WO-2J42X82lCg";
+const token =
+  "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZWFtLW9yYW5nZSIsImlhdCI6MTcyNDA0NDc5MCwiZXhwIjoxNzI0MDQ4MzkwLCJzdWIiOiJldmVudFVzZXIiLCJ1c2VyTmFtZSI6Iuq5gOyCoeu6qSIsInVzZXJJZCI6ImtpbXBpcHB5YXAiLCJyb2xlIjoiZXZlbnRfdXNlciJ9.m5m_PkwmYz5Mt-kjn28435bQtwgph3WO-2J42X82lCg";
 
 const handlers = [
   http.post("/api/v1/event-user/send-auth", async ({ request }) => {

--- a/src/mainPage/shared/auth/mock.js
+++ b/src/mainPage/shared/auth/mock.js
@@ -4,6 +4,8 @@ function isValidInput(name, phoneNumber) {
   return name.length >= 2 && phoneNumber.length < 12 && phoneNumber.startsWith("01");
 }
 
+const token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0ZWFtLW9yYW5nZSIsImlhdCI6MTcyNDA0NDc5MCwiZXhwIjoxNzI0MDQ4MzkwLCJzdWIiOiJldmVudFVzZXIiLCJ1c2VyTmFtZSI6Iuq5gOyCoeu6qSIsInVzZXJJZCI6ImtpbXBpcHB5YXAiLCJyb2xlIjoiZXZlbnRfdXNlciJ9.m5m_PkwmYz5Mt-kjn28435bQtwgph3WO-2J42X82lCg";
+
 const handlers = [
   http.post("/api/v1/event-user/send-auth", async ({ request }) => {
     const { name, phoneNumber } = await request.json();
@@ -22,7 +24,7 @@ const handlers = [
       return HttpResponse.json({ error: "응답 내용이 잘못됨" }, { status: 400 });
     if (+authCode < 500000 === false)
       return HttpResponse.json({ error: "인증번호 일치 안 함" }, { status: 401 });
-    return HttpResponse.json({ token: "test_token" });
+    return HttpResponse.json({ token });
   }),
 
   http.post("/api/v1/event-user/login", async ({ request }) => {
@@ -32,7 +34,7 @@ const handlers = [
       return HttpResponse.json({ error: "응답 내용이 잘못됨" }, { status: 400 });
     if (name !== "오렌지" || phoneNumber !== "01019991999")
       return HttpResponse.json({ error: "사용자 없음" }, { status: 404 });
-    return HttpResponse.json({ token: "test_token" });
+    return HttpResponse.json({ token });
   }),
 ];
 

--- a/src/mainPage/shared/auth/store.js
+++ b/src/mainPage/shared/auth/store.js
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { jwtDecode } from "jwt-decode";
 import tokenSaver from "@common/dataFetch/tokenSaver.js";
 import { SERVICE_TOKEN_ID } from "@common/constants.js";
 
@@ -9,7 +10,13 @@ const userStore = create(() => ({
 
 function parseTokenToUserName(token) {
   if (token === null) return "";
-  return "사용자";
+  try {
+    const { userName } = jwtDecode(token);
+    return userName;
+  }
+  catch {
+    return "사용자";
+  }
 }
 
 export function login(token) {

--- a/src/mainPage/shared/auth/store.js
+++ b/src/mainPage/shared/auth/store.js
@@ -30,7 +30,7 @@ class UserStore
     const oldState = this.state;
     const newState = typeof mutateFunc === "function" ? mutateFunc(oldState) : mutateFunc;
     if(oldState === newState) return;
-    observers.forEach( callback=>callback() );
+    this.observers.forEach( callback=>callback() );
   }
 }
 

--- a/src/mainPage/shared/auth/store.js
+++ b/src/mainPage/shared/auth/store.js
@@ -6,38 +6,32 @@ import { SERVICE_TOKEN_ID } from "@common/constants.js";
 const defaultUserState = {
   isLogin: false,
   userName: "",
-}
+};
 
-class UserStore
-{
+class UserStore {
   state;
   observers = new Set();
-  constructor()
-  {
+  constructor() {
     this.state = createUserStore();
   }
-  getState(getter)
-  {
+  getState(getter) {
     return getter(this.state);
   }
-  subscribe(callback)
-  {
+  subscribe(callback) {
     this.observers.add(callback);
-    return ()=>this.observers.delete(callback);
+    return () => this.observers.delete(callback);
   }
-  setState(mutateFunc)
-  {
+  setState(mutateFunc) {
     const oldState = this.state;
     const newState = typeof mutateFunc === "function" ? mutateFunc(oldState) : mutateFunc;
-    if(oldState === newState) return;
+    if (oldState === newState) return;
     this.state = newState;
-    this.observers.forEach( callback=>callback() );
+    this.observers.forEach((callback) => callback());
   }
 }
 
-function createUserStore()
-{
-  if(typeof window === "undefined") return defaultUserState;
+function createUserStore() {
+  if (typeof window === "undefined") return defaultUserState;
   tokenSaver.init(SERVICE_TOKEN_ID);
   const token = tokenSaver.get(SERVICE_TOKEN_ID);
   const userName = parseTokenToUserName(token);
@@ -50,8 +44,7 @@ function parseTokenToUserName(token) {
   try {
     const { userName } = jwtDecode(token);
     return userName;
-  }
-  catch {
+  } catch {
     return "사용자";
   }
 }
@@ -69,9 +62,12 @@ export function logout() {
   userStore.setState(() => ({ isLogin: false, userName: "" }));
 }
 
-function useUserStore(func, defaultValue=defaultUserState)
-{
-  return useSyncExternalStore(userStore.subscribe.bind(userStore), ()=>userStore.getState(func), ()=>func(defaultValue));
+function useUserStore(func, defaultValue = defaultUserState) {
+  return useSyncExternalStore(
+    userStore.subscribe.bind(userStore),
+    () => userStore.getState(func),
+    () => func(defaultValue),
+  );
 }
 
 export default useUserStore;

--- a/src/mainPage/shared/auth/store.js
+++ b/src/mainPage/shared/auth/store.js
@@ -30,6 +30,7 @@ class UserStore
     const oldState = this.state;
     const newState = typeof mutateFunc === "function" ? mutateFunc(oldState) : mutateFunc;
     if(oldState === newState) return;
+    this.state = newState;
     this.observers.forEach( callback=>callback() );
   }
 }

--- a/src/mainPage/shared/auth/store.js
+++ b/src/mainPage/shared/auth/store.js
@@ -1,12 +1,48 @@
-import { create } from "zustand";
+import { useSyncExternalStore } from "react";
 import { jwtDecode } from "jwt-decode";
 import tokenSaver from "@common/dataFetch/tokenSaver.js";
 import { SERVICE_TOKEN_ID } from "@common/constants.js";
 
-const userStore = create(() => ({
+const defaultUserState = {
   isLogin: false,
   userName: "",
-}));
+}
+
+class UserStore
+{
+  state;
+  observers = new Set();
+  constructor()
+  {
+    this.state = createUserStore();
+  }
+  getState(getter)
+  {
+    return getter(this.state);
+  }
+  subscribe(callback)
+  {
+    this.observers.add(callback);
+    return ()=>this.observers.delete(callback);
+  }
+  setState(mutateFunc)
+  {
+    const oldState = this.state;
+    const newState = typeof mutateFunc === "function" ? mutateFunc(oldState) : mutateFunc;
+    if(oldState === newState) return;
+    observers.forEach( callback=>callback() );
+  }
+}
+
+function createUserStore()
+{
+  if(typeof window === "undefined") return defaultUserState;
+  tokenSaver.init(SERVICE_TOKEN_ID);
+  const token = tokenSaver.get(SERVICE_TOKEN_ID);
+  const userName = parseTokenToUserName(token);
+  if (token === null) return { isLogin: false, userName: "" };
+  else return { isLogin: true, userName };
+}
 
 function parseTokenToUserName(token) {
   if (token === null) return "";
@@ -19,6 +55,8 @@ function parseTokenToUserName(token) {
   }
 }
 
+const userStore = new UserStore();
+
 export function login(token) {
   tokenSaver.set(token);
   const userName = parseTokenToUserName(token);
@@ -30,12 +68,9 @@ export function logout() {
   userStore.setState(() => ({ isLogin: false, userName: "" }));
 }
 
-export function initLoginState() {
-  tokenSaver.init(SERVICE_TOKEN_ID);
-  const token = tokenSaver.get(SERVICE_TOKEN_ID);
-  const userName = parseTokenToUserName(token);
-  if (token === null) userStore.setState(() => ({ isLogin: false, userName: "" }));
-  else userStore.setState(() => ({ isLogin: true, userName }));
+function useUserStore(func, defaultValue=defaultUserState)
+{
+  return useSyncExternalStore(userStore.subscribe.bind(userStore), ()=>userStore.getState(func), ()=>func(defaultValue));
 }
 
-export default userStore;
+export default useUserStore;

--- a/src/mainPage/shared/components/ResetButton.jsx
+++ b/src/mainPage/shared/components/ResetButton.jsx
@@ -3,7 +3,13 @@ import RefreshIcon from "./refresh.svg?react";
 
 export default function ResetButton({ onClick }) {
   return (
-    <Button onClick={onClick} styleType="ghost" backdrop="dark" aria-label="refresh" className="p-1 xl:p-2">
+    <Button
+      onClick={onClick}
+      styleType="ghost"
+      backdrop="dark"
+      aria-label="refresh"
+      className="p-1 xl:p-2"
+    >
       <RefreshIcon />
     </Button>
   );

--- a/src/mainPage/shared/components/ResetButton.jsx
+++ b/src/mainPage/shared/components/ResetButton.jsx
@@ -3,7 +3,7 @@ import RefreshIcon from "./refresh.svg?react";
 
 export default function ResetButton({ onClick }) {
   return (
-    <Button onClick={onClick} styleType="ghost" backdrop="dark" className="p-1 xl:p-2">
+    <Button onClick={onClick} styleType="ghost" backdrop="dark" aria-label="refresh" className="p-1 xl:p-2">
       <RefreshIcon />
     </Button>
   );

--- a/src/mainPage/shared/drawEvent/store.js
+++ b/src/mainPage/shared/drawEvent/store.js
@@ -1,58 +1,60 @@
 import { create } from "zustand";
-import { fetchServer, HTTPError, ServerCloseError } from "@common/dataFetch/fetchServer.js";
+import { fetchServer } from "@common/dataFetch/fetchServer.js";
 import { getQuery, getQuerySuspense } from "@common/dataFetch/getQuery.js";
-import { getServerPresiseTime } from "@common/utils.js";
-import { EVENT_DRAW_ID, EVENT_START_DATE } from "@common/constants.js";
+import { getServerPresiseTime, getDayDifference } from "@common/utils.js";
+import { EVENT_DRAW_ID, EVENT_START_DATE, DAY_MILLISEC } from "@common/constants.js";
 
-function getJoinDataEvent()
-{
-	return fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`)
-      .then(({ dates }) => {
-        let newJoinedList = [false, false, false, false, false];
-        dates.forEach((date) => {
-          const day = getDayDifference(EVENT_START_DATE, new Date(date));
-          newJoinedList[day] = true;
-        });
-        return newJoinedList;
-      })
-      .catch(() => [false, false, false, false, false]);
+function getJoinDataEvent() {
+  return fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`)
+    .then(({ dates }) => {
+      let newJoinedList = [false, false, false, false, false];
+      dates.forEach((date) => {
+        const day = getDayDifference(EVENT_START_DATE, new Date(date));
+        newJoinedList[day] = true;
+      });
+      return newJoinedList;
+    })
+    .catch(() => [false, false, false, false, false]);
 }
 
-const drawEventStore = create( (set, get)=>({
-	joinStatus : [false, false, false, false, false],
-	openBaseDate : new Date("9999-12-31"),
-	currentJoined: false,
-	getJoinData: ()=>{
-		async function promiseFn() {
-			try {
-				const [serverTime, joinStatus] = Promise.all([
-					getQuery("server-time", getServerPresiseTime),
-					getJoinDataEvent()
-				]);
-				const currentDay = getDayDifference(EVENT_START_DATE, serverTime);
-				let currentJoined = false;
-				if(currentDay >= 0 && currentDay < joinStatus.length) {
-					currentJoined = joinStatus[currentDay];
-				}
-				set({joinStatus, openBaseDate: serverTime, currentJoined });
-				return joinStatus;
-			}
-			catch {
-				set({joinStatus: [false, false, false, false, false], openBaseDate: new Date("9999-12-31")});
-				return [false, false, false, false, false];
-			}
-		}
-		return getQuerySuspense("draw-info-data", promiseFn, [set]);
-	},
-	setCurrentJoin: (value)=>{
-		set({currentJoined: value});
-	},
-	getJoinStatus: (index)=>{
-		return get().joinStatus[index];
-	},
-	getOpenStatus: (index)=>{
-		return get().openBaseDate >= EVENT_START_DATE.getTime() + index * DAY_MILLISEC;
-	}
-}) );
+const drawEventStore = create((set, get) => ({
+  joinStatus: [false, false, false, false, false],
+  openBaseDate: new Date("9999-12-31"),
+  currentJoined: false,
+  getJoinData: (logined) => {
+    async function promiseFn() {
+      try {
+        const [serverTime, joinStatus] = Promise.all([
+          getQuery("server-time", getServerPresiseTime),
+          getJoinDataEvent(),
+        ]);
+        const currentDay = getDayDifference(EVENT_START_DATE, serverTime);
+        let currentJoined = false;
+        if (currentDay >= 0 && currentDay < joinStatus.length) {
+          currentJoined = joinStatus[currentDay];
+        }
+        set({ joinStatus, openBaseDate: serverTime, currentJoined });
+        return joinStatus;
+      } catch {
+        set({
+          joinStatus: [false, false, false, false, false],
+          openBaseDate: new Date("9999-12-31"),
+          currentJoined: false,
+        });
+        return [false, false, false, false, false];
+      }
+    }
+    return getQuerySuspense(`draw-info-data@${logined}`, promiseFn, [set]);
+  },
+  setCurrentJoin: (value) => {
+    set({ currentJoined: value });
+  },
+  getJoinStatus: (index) => {
+    return get().joinStatus[index];
+  },
+  getOpenStatus: (index) => {
+    return get().openBaseDate >= EVENT_START_DATE.getTime() + index * DAY_MILLISEC;
+  },
+}));
 
 export default drawEventStore;

--- a/src/mainPage/shared/drawEvent/store.js
+++ b/src/mainPage/shared/drawEvent/store.js
@@ -1,0 +1,58 @@
+import { create } from "zustand";
+import { fetchServer, HTTPError, ServerCloseError } from "@common/dataFetch/fetchServer.js";
+import { getQuery, getQuerySuspense } from "@common/dataFetch/getQuery.js";
+import { getServerPresiseTime } from "@common/utils.js";
+import { EVENT_DRAW_ID, EVENT_START_DATE } from "@common/constants.js";
+
+function getJoinDataEvent()
+{
+	return fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`)
+      .then(({ dates }) => {
+        let newJoinedList = [false, false, false, false, false];
+        dates.forEach((date) => {
+          const day = getDayDifference(EVENT_START_DATE, new Date(date));
+          newJoinedList[day] = true;
+        });
+        return newJoinedList;
+      })
+      .catch(() => [false, false, false, false, false]);
+}
+
+const drawEventStore = create( (set, get)=>({
+	joinStatus : [false, false, false, false, false],
+	openBaseDate : new Date("9999-12-31"),
+	currentJoined: false,
+	getJoinData: ()=>{
+		async function promiseFn() {
+			try {
+				const [serverTime, joinStatus] = Promise.all([
+					getQuery("server-time", getServerPresiseTime),
+					getJoinDataEvent()
+				]);
+				const currentDay = getDayDifference(EVENT_START_DATE, serverTime);
+				let currentJoined = false;
+				if(currentDay >= 0 && currentDay < joinStatus.length) {
+					currentJoined = joinStatus[currentDay];
+				}
+				set({joinStatus, openBaseDate: serverTime, currentJoined });
+				return joinStatus;
+			}
+			catch {
+				set({joinStatus: [false, false, false, false, false], openBaseDate: new Date("9999-12-31")});
+				return [false, false, false, false, false];
+			}
+		}
+		return getQuerySuspense("draw-info-data", promiseFn, [set]);
+	},
+	setCurrentJoin: (value)=>{
+		set({currentJoined: value});
+	},
+	getJoinStatus: (index)=>{
+		return get().joinStatus[index];
+	},
+	getOpenStatus: (index)=>{
+		return get().openBaseDate >= EVENT_START_DATE.getTime() + index * DAY_MILLISEC;
+	}
+}) );
+
+export default drawEventStore;

--- a/src/mainPage/shared/realtimeEvent/store.js
+++ b/src/mainPage/shared/realtimeEvent/store.js
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import * as Status from "./constants.js";
 import { fetchServer, HTTPError, ServerCloseError } from "@common/dataFetch/fetchServer.js";
-import { getQuerySuspense } from "@common/dataFetch/getQuery.js";
+import { getQuery, getQuerySuspense } from "@common/dataFetch/getQuery.js";
 import { getServerPresiseTime } from "@common/utils.js";
 import { EVENT_FCFS_ID } from "@common/constants.js";
 
@@ -55,7 +55,7 @@ const fcfsStore = create((set) => ({
     const promiseFn = async function () {
       // get server time and event info
       const [serverTime, eventInfo] = await Promise.all([
-        getServerPresiseTime(),
+        getQuery("server-time", getServerPresiseTime),
         getFcfsEventInfo(),
       ]);
       const currentServerTime = serverTime;

--- a/src/mainPage/shared/realtimeEvent/store.js
+++ b/src/mainPage/shared/realtimeEvent/store.js
@@ -75,9 +75,9 @@ const fcfsStore = create((set) => ({
   getPariticipatedData: (isLogin) => {
     const promiseFn = async function () {
       const participated = await getFcfsParticipated();
-      set({ isParticipated: participated.answerResult });
+      set({ isParticipated: participated });
     };
-    return getQuerySuspense(`fcfs-participated-data-${isLogin}`, promiseFn, [set]);
+    return getQuerySuspense(`fcfs-participated-data@${isLogin}`, promiseFn, [set]);
   },
   setEventStatus: (eventStatus) => set({ eventStatus }),
   handleCountdown: () =>

--- a/vite.config.js
+++ b/vite.config.js
@@ -26,4 +26,12 @@ export default defineConfig({
       { find: "@admin", replacement: resolve(__dirname, "src/adminPage/shared") },
     ],
   },
+  preview: {
+    proxy: {
+      "/api": {
+        target: 'http://softeerorange.store',
+        changeOrigin: true,
+      }
+    }
+  }
 });


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #111 

# 📝 작업 내용

> 햄버거 버튼을 추가했습니다.
- 애니메이션은 구현 안 했습니다.

> 이미지 lazy loading을 적용했습니다.
<img width="945" alt="스크린샷 2024-08-19 오전 11 53 46" src="https://github.com/user-attachments/assets/d4df781f-3edf-4c73-84a6-6036e1edda36">

(이게 적용 전)

<img width="716" alt="스크린샷 2024-08-19 오후 12 22 18" src="https://github.com/user-attachments/assets/a3192d88-9ec9-4b9d-b097-f533cf0f3a85">

(이게 적용 후)

적용 전에 비해, LCP가 5초 이상 개선되었습니다.
**로컬에서** FCP 5초 지연 문제는 모르겠네요. SSG인데 대체 왜!!!

> 서버와의 응답 상태와의 호환을 맞췄습니다.
- 이제 기대평 Info api가 401 에러를 띄우더라도, 기대평 버튼이 "error"로 표시되지 않습니다.
- 로그인한 사용자가 추첨 이벤트를 참여하지 않았을 때, 기대평 등록 api에서 404 에러를 띄우는데, 이 경우에도 추첨 이벤트로 유도하는 모달의 띄워지도록 했습니다.

> 이제 사용자 이름은 제대로 표시됩니다.
- jwt 파서를 적용했습니다.

> 메인 페이지의 로그인 상태 불러오기를 개선했습니다.
- 진짜 아주 찰나지만, 이제 메인 페이지의 로그인 상태는 '즉시' 반영됩니다.
- 즉, 접속 시 로그인 상태가 false에서 true로 바뀌는 현상이 없기 때문에, 로그인 상태에 의존하는 api가 더 이상 2번 호출되지 않습니다.

> 프리뷰 서버는 이제 진짜 백엔드 서버로 api를 발송합니다.
- 이제 dev 브랜치로 머지하지 않아도 백엔드 서버와의 연동을 확인할 수 있습니다. 물론 빌드를 일일이 해야 하는 건 똑같긴 하지만요...

> 자잘한 오류를 수정했습니다.
- 리셋 버튼에 aria-label을 추가했습니다.

## 다음에 할 것
- 추첨 이벤트 참여 상태는 이제 전역으로 관리될 예정입니다.
- 인터랙션 페이지의 접근성이 개선될 예정입니다.
- 모달의 접근성이 개선될 예정입니다. (focus trap 적용 예정)
- 어드민 페이지에서 이벤트 프레임 입력에 검색 미리보기 기능이 적용될 예정입니다.