### PR TITLE
[feat] 어드민 기대평 잡다 기능

### DIFF
--- a/src/adminPage/features/comment/id/Comments.jsx
+++ b/src/adminPage/features/comment/id/Comments.jsx
@@ -1,23 +1,25 @@
 import { useQuery } from "@common/dataFetch/getQuery.js";
 import { fetchServer } from "@common/dataFetch/fetchServer.js";
+import Pagination from "@admin/components/Pagination";
+import { useState } from "react";
 
 export default function Comments({
   eventId,
   checkedComments,
   setCheckedComments,
-  page,
   setAllId,
   searchString,
 }) {
+  const [page, setPage] = useState(1);
   const data = useQuery(
     eventId,
     () =>
       fetchServer(
-        `/api/v1/admin/comments?eventId=${eventId}&page=${page}&size=15${searchString && "&search=" + searchString}`,
+        `/api/v1/admin/comments?eventId=${eventId}&page=${page - 1}&size=15${searchString && "&search=" + searchString}`,
       )
-        .then(({ comments }) => {
-          setAllId(comments.map((comment) => comment.id));
-          return comments;
+        .then((res) => {
+          setAllId(res.comments.map((comment) => comment.id));
+          return res;
         })
         .catch((e) => {
           console.log(e);
@@ -60,8 +62,8 @@ export default function Comments({
   }
 
   return (
-    <div className="mt-1 mb-5 flex flex-col gap-1 w-full">
-      {data.map((comment) => (
+    <div className="mt-1 mb-5 flex flex-col items-center gap-1 w-full">
+      {data.comments.map((comment) => (
         <div
           key={comment.id}
           onClick={() => checkComment(comment.id)}
@@ -83,6 +85,8 @@ export default function Comments({
           <span className="text-body-s">{truncateString(comment.content)}</span>
         </div>
       ))}
+
+      <Pagination currentPage={page} setPage={setPage} maxPage={data.totalPages} />
     </div>
   );
 }

--- a/src/adminPage/features/comment/id/Comments.jsx
+++ b/src/adminPage/features/comment/id/Comments.jsx
@@ -53,14 +53,6 @@ export default function Comments({
     }
   }
 
-  function truncateString(str) {
-    if (str.length > 50) {
-      return str.substring(0, 50) + "...";
-    } else {
-      return str;
-    }
-  }
-
   return (
     <div className="mt-1 mb-5 flex flex-col items-center gap-1 w-full">
       {data.comments.map((comment) => (
@@ -82,7 +74,7 @@ export default function Comments({
             <span className="text-neutral-500">{getTime(comment.createdAt)}</span>
           </div>
 
-          <span className="text-body-s">{truncateString(comment.content)}</span>
+          <span className="pr-4 overflow-hidden text-body-s text-ellipsis">{comment.content}</span>
         </div>
       ))}
 

--- a/src/adminPage/features/comment/id/index.jsx
+++ b/src/adminPage/features/comment/id/index.jsx
@@ -2,12 +2,10 @@ import Suspense from "@common/components/Suspense";
 import Loading from "./Loading.jsx";
 import Comments from "./Comments.jsx";
 import { useState } from "react";
-import Pagination from "@admin/components/Pagination";
 import DeleteButton from "./DeleteButton.jsx";
 
 export default function AdminCommentID({ eventId }) {
   const [checkedComments, setCheckedComments] = useState(new Set());
-  const [page, setPage] = useState(1);
   const [formString, setFormString] = useState("");
   const [searchString, setSearchString] = useState("");
   const [allId, setAllId] = useState([]);
@@ -78,13 +76,10 @@ export default function AdminCommentID({ eventId }) {
           eventId={eventId}
           checkedComments={checkedComments}
           setCheckedComments={setCheckedComments}
-          page={page - 1}
           setAllId={setAllId}
           searchString={searchString}
         />
       </Suspense>
-
-      <Pagination currentPage={page} setPage={setPage} maxPage={10} />
     </div>
   );
 }

--- a/src/adminPage/features/comment/index.jsx
+++ b/src/adminPage/features/comment/index.jsx
@@ -54,7 +54,7 @@ export default function AdminComment() {
   }
 
   function onKeyDown(e) {
-    if (!isSpread || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
+    if (!isSpread || !searchList.length || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
     e.preventDefault();
     let nextIndex = selectedEvent;
 

--- a/src/adminPage/features/comment/index.jsx
+++ b/src/adminPage/features/comment/index.jsx
@@ -7,12 +7,12 @@ export default function AdminComment() {
   const [formString, setFormString] = useState("");
   const [isSpread, setIsSpread] = useState(false);
   const [searchList, setSearchList] = useState([]);
+  const [selectedEvent, setSelectedEvent] = useState(-1);
 
-  function autoCorrect() {
-    fetchServer(`/api/v1/admin/events/hints?search=${formString}`)
+  function autoCorrect(str) {
+    fetchServer(`/api/v1/admin/events/hints?search=${str}`)
       .then((res) => {
         setSearchList(res);
-        setIsSpread(true);
       })
       .catch((e) => {
         console.log(e);
@@ -20,30 +20,53 @@ export default function AdminComment() {
   }
 
   function onChangeForm(e) {
-    const filteredString = e.target.value.replace(/[^0-9]/g, "");
+    let newString = e.target.value.replace(/[^0-9]/g, "");
 
-    if (!filteredString) {
-      setFormString("");
-    } else if (filteredString.length <= 6) {
-      setFormString("HD_" + filteredString);
-    } else if (filteredString.length <= 9) {
-      setFormString("HD_" + filteredString.slice(0, 6) + "_" + filteredString.slice(6));
+    if (!newString) {
+      newString = "";
+    } else if (newString.length <= 6) {
+      newString = "HD_" + newString;
+    } else if (newString.length <= 9) {
+      newString = "HD_" + newString.slice(0, 6) + "_" + newString.slice(6);
     } else return;
 
-    if (filteredString.length >= 6) {
-      autoCorrect();
-    } else setIsSpread(false);
+    if (newString !== formString) {
+      if (newString.length >= 9) {
+        setSelectedEvent(-1);
+        setIsSpread(true);
+        autoCorrect(newString);
+      } else {
+        setIsSpread(false);
+      }
+    }
+    setFormString(newString);
   }
 
   function searchEvent(e, eventId) {
     e.preventDefault();
 
     const eventIDRegex = /^HD_\d{6}_\d{3}$/;
-    const searchID = eventId ? eventId : formString;
+    const searchID = eventId ?? formString;
 
     if (eventIDRegex.test(searchID)) {
       navigate(`/comments/${searchID}`);
     }
+  }
+
+  function onKeyDown(e) {
+    if (!isSpread || (e.key !== "ArrowUp" && e.key !== "ArrowDown")) return;
+    e.preventDefault();
+    let nextIndex = selectedEvent;
+
+    if (e.key === "ArrowUp") {
+      if (nextIndex === -1) nextIndex++;
+      nextIndex = (nextIndex - 1 + searchList.length) % searchList.length;
+    } else {
+      nextIndex = (nextIndex + 1) % searchList.length;
+    }
+
+    setSelectedEvent(nextIndex);
+    setFormString(searchList[nextIndex].eventId);
   }
 
   return (
@@ -53,18 +76,20 @@ export default function AdminComment() {
         inputMode="numeric"
         onChange={onChangeForm}
         value={formString}
+        onKeyDown={onKeyDown}
         placeholder="ID (숫자 9자리)"
         className={`z-10 bg-neutral-50 focus:bg-white px-4 py-2 w-full ${isSpread ? "rounded-t-md" : "rounded-md"}`}
       />
 
       <div
-        className={`absolute max-h-40 top-full border overflow-y-auto w-full rounded-b-md px-3 py-2 flex flex-col gap-2 ${!isSpread && "hidden"}`}
+        className={`absolute top-full border overflow-y-auto w-full rounded-b-md px-3 py-2 flex flex-col gap-2 ${!isSpread && "hidden"}`}
       >
-        {searchList.map((evt) => (
+        {searchList.map((evt, index) => (
           <li
             key={evt.eventId}
+            onMouseEnter={() => setSelectedEvent(index)}
             onClick={(e) => searchEvent(e, evt.eventId)}
-            className={`cursor-pointer list-none w-full rounded px-1 flex hover:bg-blue-200`}
+            className={`cursor-pointer list-none w-full rounded px-1 flex ${index === selectedEvent && "bg-blue-200"}`}
           >
             <span className="w-40">{evt.eventId}</span>
             <span>{evt.name}</span>

--- a/src/adminPage/features/comment/mock.js
+++ b/src/adminPage/features/comment/mock.js
@@ -30,7 +30,7 @@ function getSampleCommentList() {
       },
     ];
   }
-  return { comments: commentList };
+  return { comments: commentList, totalPages: 15 };
 }
 
 const handlers = [

--- a/src/adminPage/features/comment/mock.js
+++ b/src/adminPage/features/comment/mock.js
@@ -24,7 +24,7 @@ function getSampleCommentList() {
       ...commentList,
       {
         id: i,
-        content: getRandomString(100),
+        content: getRandomString(150),
         userName: getRandomString(5),
         createdAt: "2024-08-14T07:11:27.244Z",
       },

--- a/src/adminPage/features/eventList/queryReducer.js
+++ b/src/adminPage/features/eventList/queryReducer.js
@@ -55,7 +55,7 @@ export function searchStateToQuery(state) {
       .filter(([, value]) => value !== "none")
       .map(([key, value]) => `${key}:${value}`)
       .join(","),
-    page: state.page,
+    page: state.page - 1,
     size: 10,
   };
   if (state.query === "") delete paramObj.search;


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #32

- 어드민 기대평 검색 페이지 기대평 목록 pagination에서 최대 페이지까지만 조회 가능하게 함
> 최대 페이지 정보는 기대평 받아오는 api에서 같이 받아옵니다.
- 기대평 내용이 요소 넘칠 시 ... 출력
> 기획서에서는 최대 50자까지만 출력하라고 나와 있지만, 한글과 영어가 섞이면 UI상 아름답지 않아 최대 글자수 제한보다 요소 크기를 넘어가면 ```text-ellipsis```를 적용해서 ...를 출력하도록 했습니다.
- 이벤트 검색에서 자동완성 시 위/아래 방향키로 이벤트 선택 가능