### PR TITLE
[modify] 로그아웃 기능 추가, 자잘한 버그 수정, 접근성 개선

### DIFF
--- a/src/adminPage/features/eventEdit/index.jsx
+++ b/src/adminPage/features/eventEdit/index.jsx
@@ -51,7 +51,7 @@ function EventEditor({ initialData = null } = {}) {
             title={`${mode === "create" ? "등록" : "수정"} 완료`}
             description={`이벤트가 성공적으로 ${mode === "create" ? "등록" : "수정"}되었습니다!`}
           />,
-        ).then( ()=>navigate(mode === "create" ? "/events" : `/events/${state.eventId}`) );
+        ).then(() => navigate(mode === "create" ? "/events" : `/events/${state.eventId}`));
       },
       onError: (e) => {
         openModal(<AlertModal title="등록 실패" description={e.message} />);

--- a/src/adminPage/features/eventEdit/index.jsx
+++ b/src/adminPage/features/eventEdit/index.jsx
@@ -51,8 +51,7 @@ function EventEditor({ initialData = null } = {}) {
             title={`${mode === "create" ? "등록" : "수정"} 완료`}
             description={`이벤트가 성공적으로 ${mode === "create" ? "등록" : "수정"}되었습니다!`}
           />,
-        );
-        navigate(mode === "create" ? "/events" : `/events/${state.eventId}`);
+        ).then( ()=>navigate(mode === "create" ? "/events" : `/events/${state.eventId}`) );
       },
       onError: (e) => {
         openModal(<AlertModal title="등록 실패" description={e.message} />);

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,4 +1,4 @@
-export const EVENT_FCFS_ID = 1;
+export const EVENT_FCFS_ID = "HD_240808_001";
 export const EVENT_DRAW_ID = "HD-19700101-01";
 export const EVENT_ID = "the-new-ioniq5";
 export const EVENT_START_DATE = new Date(2024, 8, 9);

--- a/src/common/dataFetch/getQuery.js
+++ b/src/common/dataFetch/getQuery.js
@@ -103,18 +103,20 @@ export function useQuery(key, promiseFn, config = {}) {
  *
  * @return Function : 호출 시, 실제로 post 요청을 발송하는 함수를 반환합니다.
  */
+export async function mutate(key, promiseFn, { onSuccess, onError } = {}) {
+  try {
+    const value = await promiseFn();
+    updateSubscribedQuery(key);
+    onSuccess?.(value);
+    return value;
+  } catch (e) {
+    onError?.(e);
+    if (onError === undefined) throw e;
+  }
+}
+
 export function useMutation(key, promiseFn, { onSuccess, onError } = {}) {
-  return async () => {
-    try {
-      const value = await promiseFn();
-      updateSubscribedQuery(key);
-      onSuccess?.(value);
-      return value;
-    } catch (e) {
-      onError?.(e);
-      if (onError === undefined) throw e;
-    }
-  };
+  return () => mutate(key, promiseFn, { onSuccess, onError });
 }
 
 export function getQuerySuspense(key, promiseFn, dependencyArray = []) {

--- a/src/common/modal/modal.jsx
+++ b/src/common/modal/modal.jsx
@@ -31,17 +31,16 @@ function Modal({ layer }) {
   }, [child]);
 
   useEffect(() => {
-    if(child === null) return;
+    if (child === null) return;
 
-    function escHatch(e)
-    {
-      if(e.key !== "Escape") return;
+    function escHatch(e) {
+      if (e.key !== "Escape") return;
       close();
       e.preventDefault();
     }
-    document.addEventListener( "keydown", escHatch );
-    return ()=>document.removeEventListener( "keydown", escHatch );
-  }, [child]);
+    document.addEventListener("keydown", escHatch);
+    return () => document.removeEventListener("keydown", escHatch);
+  }, [child, close]);
 
   const focusTrapRef = useFocusTrap(child !== null);
 

--- a/src/common/modal/modal.jsx
+++ b/src/common/modal/modal.jsx
@@ -30,6 +30,19 @@ function Modal({ layer }) {
     }
   }, [child]);
 
+  useEffect(() => {
+    if(child === null) return;
+
+    function escHatch(e)
+    {
+      if(e.key !== "Escape") return;
+      close();
+      e.preventDefault();
+    }
+    document.addEventListener( "keydown", escHatch );
+    return ()=>document.removeEventListener( "keydown", escHatch );
+  }, [child]);
+
   const focusTrapRef = useFocusTrap(child !== null);
 
   return (

--- a/src/common/modal/modal.jsx
+++ b/src/common/modal/modal.jsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useEffect, useState, useRef } from "react";
 import useModalStore, { closeModal } from "./store.js";
+import useFocusTrap from "./useFocusTrap.js";
 
 export const ModalCloseContext = createContext(() => {
   console.log("모달이 닫힙니다.");
@@ -29,11 +30,14 @@ function Modal({ layer }) {
     }
   }, [child]);
 
+  const focusTrapRef = useFocusTrap(child !== null);
+
   return (
     <ModalCloseContext.Provider value={close}>
       {child !== null ? (
         <div
           className={`fixed z-[100] top-0 left-0 w-full h-dvh flex justify-center items-center transition-opacity ${opacity === 0 ? "opacity-0" : "opacity-100"}`}
+          ref={focusTrapRef}
         >
           {child}
           <div

--- a/src/common/modal/openModal.js
+++ b/src/common/modal/openModal.js
@@ -1,15 +1,14 @@
 import { modalStore } from "./store.js";
 
 export default function openModal(component, layer = "alert") {
-  modalStore.changeModal(component, layer); 
-  return new Promise( (resolve)=>{
-    function observe()
-    {
-      if(modalStore.getSnapshot(layer) !== component) {
+  modalStore.changeModal(component, layer);
+  return new Promise((resolve) => {
+    function observe() {
+      if (modalStore.getSnapshot(layer) !== component) {
         resolve();
         clear();
       }
     }
-    const clear = modalStore.subscribe( observe );
-  } );
+    const clear = modalStore.subscribe(observe);
+  });
 }

--- a/src/common/modal/openModal.js
+++ b/src/common/modal/openModal.js
@@ -1,5 +1,15 @@
 import { modalStore } from "./store.js";
 
 export default function openModal(component, layer = "alert") {
-  modalStore.changeModal(component, layer);
+  modalStore.changeModal(component, layer); 
+  return new Promise( (resolve)=>{
+    function observe()
+    {
+      if(modalStore.getSnapshot(layer) !== component) {
+        resolve();
+        clear();
+      }
+    }
+    const clear = modalStore.subscribe( observe );
+  } );
 }

--- a/src/common/modal/useFocusTrap.js
+++ b/src/common/modal/useFocusTrap.js
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from "react";
+
+function getEndPointChild(element)
+{
+	const focusableElements = [...element.querySelectorAll(
+  "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]"
+)].filter( elem=>elem.tabIndex >= 0 );
+	if(focusableElements.length === 0) return [null, null];
+	return [focusableElements[0], focusableElements[focusableElements.length - 1]];
+}
+
+function useFocusTrap(active)
+{
+	const prevRef = useRef(null);
+	const ref = useRef(null);
+	const endPointChild = useRef([null, null]);
+	useEffect( ()=>{
+		if(!active || ref.current === null) return;
+
+		function renewEndPointChild()
+		{
+			if(ref.current === null) return;
+			endPointChild.current = getEndPointChild(ref.current);
+		}
+
+		function handleTabKey(e) {
+			if(e.key !== "Tab") return;
+
+			const [first, last] = endPointChild.current;
+
+			if(document.activeElement === prevRef.current) {
+				if(e.shiftKey) last?.focus();
+				else first?.focus();
+				e.preventDefault();
+				return;
+			}
+
+			if(first === null || last === null) return;
+			if(document.activeElement === last && !e.shiftKey) {
+				first.focus();
+				e.preventDefault();
+			}
+			else if(document.activeElement === first && e.shiftKey) {
+				last.focus();
+				e.preventDefault();
+			}
+		}
+
+		renewEndPointChild();
+		prevRef.current = document.activeElement;
+		document.addEventListener("keydown", handleTabKey);
+		const config = { subtree: true, childList: true, attributeFilter: ["disabled", "tabindex"] };
+		const observer = new MutationObserver( renewEndPointChild );
+		observer.observe(ref.current, config);
+
+		return ()=>{
+			document.removeEventListener("keydown", handleTabKey);
+			observer.disconnect();
+			prevRef.current.focus();
+		}
+
+	}, [active] );
+
+	return ref;
+}
+
+export default useFocusTrap;

--- a/src/common/modal/useFocusTrap.js
+++ b/src/common/modal/useFocusTrap.js
@@ -1,67 +1,64 @@
 import { useEffect, useRef } from "react";
 
-function getEndPointChild(element)
-{
-	const focusableElements = [...element.querySelectorAll(
-  "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]"
-)].filter( elem=>elem.tabIndex >= 0 );
-	if(focusableElements.length === 0) return [null, null];
-	return [focusableElements[0], focusableElements[focusableElements.length - 1]];
+function getEndPointChild(element) {
+  const focusableElements = [
+    ...element.querySelectorAll(
+      "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]",
+    ),
+  ].filter((elem) => elem.tabIndex >= 0);
+  if (focusableElements.length === 0) return [null, null];
+  return [focusableElements[0], focusableElements[focusableElements.length - 1]];
 }
 
-function useFocusTrap(active)
-{
-	const prevRef = useRef(null);
-	const ref = useRef(null);
-	const endPointChild = useRef([null, null]);
-	useEffect( ()=>{
-		if(!active || ref.current === null) return;
+function useFocusTrap(active) {
+  const prevRef = useRef(null);
+  const ref = useRef(null);
+  const endPointChild = useRef([null, null]);
+  useEffect(() => {
+    if (!active || ref.current === null) return;
 
-		function renewEndPointChild()
-		{
-			if(ref.current === null) return;
-			endPointChild.current = getEndPointChild(ref.current);
-		}
+    function renewEndPointChild() {
+      if (ref.current === null) return;
+      endPointChild.current = getEndPointChild(ref.current);
+    }
 
-		function handleTabKey(e) {
-			if(e.key !== "Tab") return;
+    function handleTabKey(e) {
+      if (e.key !== "Tab") return;
 
-			const [first, last] = endPointChild.current;
+      const [first, last] = endPointChild.current;
 
-			if(document.activeElement === prevRef.current) {
-				if(e.shiftKey) last?.focus();
-				else first?.focus();
-				e.preventDefault();
-				return;
-			}
+      if (document.activeElement === prevRef.current) {
+        if (e.shiftKey) last?.focus();
+        else first?.focus();
+        e.preventDefault();
+        return;
+      }
 
-			if(first === null || last === null) return;
-			if(document.activeElement === last && !e.shiftKey) {
-				first.focus();
-				e.preventDefault();
-			}
-			else if(document.activeElement === first && e.shiftKey) {
-				last.focus();
-				e.preventDefault();
-			}
-		}
+      if (first === null || last === null) return;
+      if (document.activeElement === last && !e.shiftKey) {
+        first.focus();
+        e.preventDefault();
+      } else if (document.activeElement === first && e.shiftKey) {
+        last.focus();
+        e.preventDefault();
+      }
+    }
 
-		renewEndPointChild();
-		prevRef.current = document.activeElement;
-		document.addEventListener("keydown", handleTabKey);
-		const config = { subtree: true, childList: true, attributeFilter: ["disabled", "tabindex"] };
-		const observer = new MutationObserver( renewEndPointChild );
-		observer.observe(ref.current, config);
+    renewEndPointChild();
+    prevRef.current = document.activeElement;
+    document.addEventListener("keydown", handleTabKey);
+    const config = { subtree: true, childList: true, attributeFilter: ["disabled", "tabindex"] };
+    const observer = new MutationObserver(renewEndPointChild);
+    observer.observe(ref.current, config);
 
-		return ()=>{
-			document.removeEventListener("keydown", handleTabKey);
-			observer.disconnect();
-			prevRef.current.focus();
-		}
+    return () => {
+      document.removeEventListener("keydown", handleTabKey);
+      observer.disconnect();
+      prevRef.current.focus();
+    };
+  }, [active]);
 
-	}, [active] );
-
-	return ref;
+  return ref;
 }
 
 export default useFocusTrap;

--- a/src/mainPage/features/comment/autoScrollCarousel/index.jsx
+++ b/src/mainPage/features/comment/autoScrollCarousel/index.jsx
@@ -3,7 +3,8 @@ import useAutoCarousel from "./useAutoCarousel.js";
 function AutoScrollCarousel({ speed = 1, gap = 0, children }) {
   const { position, ref, eventListener } = useAutoCarousel(speed, gap);
 
-  const flexStyle = "min-w-full flex [&>div]:flex-shrink-0 gap-[var(--gap,0)] justify-around items-center absolute";
+  const flexStyle =
+    "min-w-full flex [&>div]:flex-shrink-0 gap-[var(--gap,0)] justify-around items-center absolute";
   return (
     <div className="w-full h-full overflow-hidden" {...eventListener}>
       <div
@@ -13,11 +14,15 @@ function AutoScrollCarousel({ speed = 1, gap = 0, children }) {
         }}
         className="relative h-max touch-pan-y"
       >
-        <div className={`${flexStyle} -translate-x-[calc(100%+var(--gap,0px))]`} aria-hidden="true">{children}</div>
+        <div className={`${flexStyle} -translate-x-[calc(100%+var(--gap,0px))]`} aria-hidden="true">
+          {children}
+        </div>
         <div className={flexStyle} ref={ref}>
           {children}
         </div>
-        <div className={`${flexStyle} translate-x-[calc(100%+var(--gap,0px))]`} aria-hidden="true">{children}</div>
+        <div className={`${flexStyle} translate-x-[calc(100%+var(--gap,0px))]`} aria-hidden="true">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/mainPage/features/comment/autoScrollCarousel/index.jsx
+++ b/src/mainPage/features/comment/autoScrollCarousel/index.jsx
@@ -1,9 +1,9 @@
 import useAutoCarousel from "./useAutoCarousel.js";
 
 function AutoScrollCarousel({ speed = 1, gap = 0, children }) {
-  const { position, ref, eventListener } = useAutoCarousel(speed);
+  const { position, ref, eventListener } = useAutoCarousel(speed, gap);
 
-  const flexStyle = "flex [&>div]:flex-shrink-0 gap-[var(--gap,0)] items-center absolute";
+  const flexStyle = "min-w-full flex [&>div]:flex-shrink-0 gap-[var(--gap,0)] justify-around items-center absolute";
   return (
     <div className="w-full h-full overflow-hidden" {...eventListener}>
       <div

--- a/src/mainPage/features/comment/autoScrollCarousel/index.jsx
+++ b/src/mainPage/features/comment/autoScrollCarousel/index.jsx
@@ -13,11 +13,11 @@ function AutoScrollCarousel({ speed = 1, gap = 0, children }) {
         }}
         className="relative h-max touch-pan-y"
       >
-        <div className={`${flexStyle} -translate-x-[calc(100%+var(--gap,0px))]`}>{children}</div>
+        <div className={`${flexStyle} -translate-x-[calc(100%+var(--gap,0px))]`} aria-hidden="true">{children}</div>
         <div className={flexStyle} ref={ref}>
           {children}
         </div>
-        <div className={`${flexStyle} translate-x-[calc(100%+var(--gap,0px))]`}>{children}</div>
+        <div className={`${flexStyle} translate-x-[calc(100%+var(--gap,0px))]`} aria-hidden="true">{children}</div>
       </div>
     </div>
   );

--- a/src/mainPage/features/comment/autoScrollCarousel/useAutoCarousel.js
+++ b/src/mainPage/features/comment/autoScrollCarousel/useAutoCarousel.js
@@ -5,7 +5,7 @@ const FRICTION_RATE = 0.1;
 const MOMENTUM_THRESHOLD = 0.6;
 const MOMENTUM_RATE = 0.3;
 
-function useAutoCarousel(speed = 1) {
+function useAutoCarousel(speed = 1, gap = 0) {
   const childRef = useRef(null);
   const [position, setPosition] = useState(0);
   const [isControlled, setIsControlled] = useState(false);
@@ -19,7 +19,7 @@ function useAutoCarousel(speed = 1) {
     (time) => {
       if (childRef.current === null) return;
 
-      const width = childRef.current.clientWidth;
+      const width = childRef.current.clientWidth + gap;
 
       // 마우스 뗐을 때 관성 재계산
       const baseSpeed = isHovered ? 0 : speed;

--- a/src/mainPage/features/comment/autoScrollCarousel/useAutoCarousel.js
+++ b/src/mainPage/features/comment/autoScrollCarousel/useAutoCarousel.js
@@ -38,7 +38,7 @@ function useAutoCarousel(speed = 1, gap = 0) {
       // 타임스탬프 저장
       timestamp.current = time;
     },
-    [isHovered, speed],
+    [isHovered, speed, gap],
   );
 
   useEffect(() => {

--- a/src/mainPage/features/comment/commentCarousel/CommentCarousel.jsx
+++ b/src/mainPage/features/comment/commentCarousel/CommentCarousel.jsx
@@ -15,7 +15,7 @@ function mask(string) {
 function CommentCarousel() {
   const { comments } = useQuery("comment-data", () => fetchServer(`/api/v1/comment/${EVENT_ID}`));
 
-  if(comments.length === 0) return <CommentCarouselNoData />;
+  if (comments.length === 0) return <CommentCarouselNoData />;
 
   return (
     <div className="w-full h-[29rem]">

--- a/src/mainPage/features/comment/commentCarousel/CommentCarousel.jsx
+++ b/src/mainPage/features/comment/commentCarousel/CommentCarousel.jsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@common/dataFetch/getQuery.js";
 import { fetchServer } from "@common/dataFetch/fetchServer.js";
+import CommentCarouselNoData from "./CommentCarouselNoData.jsx";
 import AutoScrollCarousel from "../autoScrollCarousel";
 import { formatDate } from "@common/utils.js";
 import { EVENT_ID } from "@common/constants.js";
@@ -13,6 +14,8 @@ function mask(string) {
 
 function CommentCarousel() {
   const { comments } = useQuery("comment-data", () => fetchServer(`/api/v1/comment/${EVENT_ID}`));
+
+  if(comments.length === 0) return <CommentCarouselNoData />;
 
   return (
     <div className="w-full h-[29rem]">

--- a/src/mainPage/features/comment/commentCarousel/CommentCarouselNoData.jsx
+++ b/src/mainPage/features/comment/commentCarousel/CommentCarouselNoData.jsx
@@ -1,0 +1,12 @@
+function CommentCarouselNoData() {
+  return (
+    <div className="w-full h-[29rem] flex justify-center items-center px-6">
+      <div className="w-full max-w-[1200px] h-96 bg-neutral-50 flex flex-col justify-center items-center gap-4">
+        <img src="/icons/error.svg" alt="기대평 없음" width="120" height="120" />
+        <p className="text-body-l text-red-500 font-bold">기대평이 없어요!</p>
+      </div>
+    </div>
+  );
+}
+
+export default CommentCarouselNoData;

--- a/src/mainPage/features/comment/mock.js
+++ b/src/mainPage/features/comment/mock.js
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 import { makeLorem } from "@common/mock/utils.js";
 
 function getCommentMock() {
-  return Array.from({ length: 2 }, (_, i) => {
+  return Array.from({ length: 20 }, (_, i) => {
     return {
       id: i * 100 + Math.floor(Math.random() * 99),
       content: makeLorem(5, 12),

--- a/src/mainPage/features/comment/mock.js
+++ b/src/mainPage/features/comment/mock.js
@@ -2,7 +2,7 @@ import { http, HttpResponse } from "msw";
 import { makeLorem } from "@common/mock/utils.js";
 
 function getCommentMock() {
-  return Array.from({ length: 20 }, (_, i) => {
+  return Array.from({ length: 2 }, (_, i) => {
     return {
       id: i * 100 + Math.floor(Math.random() * 99),
       content: makeLorem(5, 12),

--- a/src/mainPage/features/comment/modals/CommentNegativeModal.jsx
+++ b/src/mainPage/features/comment/modals/CommentNegativeModal.jsx
@@ -1,22 +1,20 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
 function CommentNegativeModal() {
   const close = useContext(ModalCloseContext);
 
   return (
-    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[15.625rem] p-10 shadow bg-white relative flex flex-col justify-between items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <p className="text-body-l font-bold text-neutral-700">해당 기대평을 등록할 수 없습니다</p>
-        <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
-          비속어, 혐오표현 등 타인에게 불쾌감을 줄 수 있는 표현이 포함된 기대평은 작성이 불가합니다
-        </p>
-      </div>
+    <AlertModalContainer
+      title="해당 기대평을 등록할 수 없습니다"
+      description="비속어, 혐오표현 등 타인에게 불쾌감을 줄 수 있는 표현이 포함된 기대평은 작성이 불가합니다"
+    >
       <Button styleType="filled" onClick={close}>
         확인
       </Button>
-    </div>
+    </AlertModalContainer>
   );
 }
 

--- a/src/mainPage/features/comment/modals/CommentNoUserModal.jsx
+++ b/src/mainPage/features/comment/modals/CommentNoUserModal.jsx
@@ -1,5 +1,6 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 import scrollTo from "@main/scroll/scrollTo.js";
 import { INTERACTION_SECTION } from "@main/scroll/constants.js";
@@ -13,22 +14,17 @@ function CommentNoUserModal() {
   }
 
   return (
-    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[31.25rem] p-10 shadow bg-white relative flex flex-col justify-between items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <p className="text-body-l font-bold text-neutral-700">아직 기대평을 작성할 수 없습니다.</p>
-        <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
-          오늘의 추첨 이벤트에 참여하고 기대평을 작성하세요
-        </p>
-      </div>
-      <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
-        <img
-          src="/icons/waiting@1x.png"
-          srcSet="/icons/waiting@1x.png 1x, /icons/waiting@2x.png 2x"
-          alt="추첨 이벤트 참여 바랍니다"
-          width="208"
-          height="40"
-        />
-      </div>
+    <AlertModalContainer
+      title="아직 기대평을 작성할 수 없습니다."
+      description="오늘의 추첨 이벤트에 참여하고 기대평을 작성하세요"
+      image={<img
+        src="/icons/waiting@1x.png"
+        srcSet="/icons/waiting@1x.png 1x, /icons/waiting@2x.png 2x"
+        alt="추첨 이벤트 참여 바랍니다"
+        width="208"
+        height="40"
+      />}
+    >
       <div className="w-full flex flex-wrap justify-center gap-5">
         <Button styleType="filled" onClick={toMoveInteraction}>
           추첨 이벤트 참여하기
@@ -37,7 +33,7 @@ function CommentNoUserModal() {
           닫기
         </Button>
       </div>
-    </div>
+    </AlertModalContainer>
   );
 }
 

--- a/src/mainPage/features/comment/modals/CommentNoUserModal.jsx
+++ b/src/mainPage/features/comment/modals/CommentNoUserModal.jsx
@@ -17,13 +17,15 @@ function CommentNoUserModal() {
     <AlertModalContainer
       title="아직 기대평을 작성할 수 없습니다."
       description="오늘의 추첨 이벤트에 참여하고 기대평을 작성하세요"
-      image={<img
-        src="/icons/waiting@1x.png"
-        srcSet="/icons/waiting@1x.png 1x, /icons/waiting@2x.png 2x"
-        alt="추첨 이벤트 참여 바랍니다"
-        width="208"
-        height="40"
-      />}
+      image={
+        <img
+          src="/icons/waiting@1x.png"
+          srcSet="/icons/waiting@1x.png 1x, /icons/waiting@2x.png 2x"
+          alt="추첨 이벤트 참여 바랍니다"
+          width="208"
+          height="40"
+        />
+      }
     >
       <div className="w-full flex flex-wrap justify-center gap-5">
         <Button styleType="filled" onClick={toMoveInteraction}>

--- a/src/mainPage/features/comment/modals/CommentSuccessModal.jsx
+++ b/src/mainPage/features/comment/modals/CommentSuccessModal.jsx
@@ -1,26 +1,26 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
 function CommentSuccessModal() {
   const close = useContext(ModalCloseContext);
 
   return (
-    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[31.25rem] p-10 shadow bg-white relative flex flex-col justify-between items-center">
-      <p className="text-body-l font-bold text-neutral-700">기대평이 등록되었습니다!</p>
-      <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
-        <img
+    <AlertModalContainer
+      title="기대평이 등록되었습니다!"
+      image={<img
           src="/icons/register@1x.png"
           srcSet="/icons/register@1x.png 1x, /icons/register@2x.png 2x"
           alt="기대평 등록 완료"
           width="173"
           height="182"
-        />
-      </div>
+        />}
+    >
       <Button styleType="ghost" onClick={close}>
         확인
       </Button>
-    </div>
+    </AlertModalContainer>
   );
 }
 

--- a/src/mainPage/features/comment/modals/CommentSuccessModal.jsx
+++ b/src/mainPage/features/comment/modals/CommentSuccessModal.jsx
@@ -9,13 +9,15 @@ function CommentSuccessModal() {
   return (
     <AlertModalContainer
       title="기대평이 등록되었습니다!"
-      image={<img
+      image={
+        <img
           src="/icons/register@1x.png"
           srcSet="/icons/register@1x.png 1x, /icons/register@2x.png 2x"
           alt="기대평 등록 완료"
           width="173"
           height="182"
-        />}
+        />
+      }
     >
       <Button styleType="ghost" onClick={close}>
         확인

--- a/src/mainPage/features/detailInformation/DetailSwiper.jsx
+++ b/src/mainPage/features/detailInformation/DetailSwiper.jsx
@@ -8,8 +8,9 @@ function DetailSwiper({ content }) {
   const isLastPage = page === content.length - 1;
 
   const slideClass = "w-[calc(100%-96px)] min-[1024px]:w-full max-w-[1200px] bg-yellow-400";
-  const navigationClass = `invisible absolute [--size:3rem] md:[--size:4.5rem] top-[calc(50%-var(--size)*0.5)] size-[var(--size)] p-2 md:p-4 
-	flex justify-center items-center rounded-full bg-neutral-100 active:bg-neutral-200 z-10 cursor-pointer select-none`;
+  const navigationClass = `absolute [--size:0px] lg:[--size:4.5rem] top-[calc(50%-var(--size)*0.5)] size-[var(--size)] p-0 lg:p-4 
+	flex justify-center items-center rounded-full disabled:hidden
+  bg-neutral-100 active:bg-neutral-200 z-10 cursor-pointer select-none`;
 
   return (
     <div className="w-full flex flex-col items-center gap-10">
@@ -19,6 +20,7 @@ function DetailSwiper({ content }) {
           slides-per-view="auto"
           centered-slides="true"
           space-between="12"
+          a11y="true"
           breakpoints='{"1024":{"spaceBetween":400}}'
           ref={swiperElRef}
         >
@@ -29,7 +31,8 @@ function DetailSwiper({ content }) {
           ))}
         </swiper-container>
         <button
-          className={`${navigationClass} left-6 ${page === 0 ? "" : "lg:visible"}`}
+          className={`${navigationClass} left-6`}
+          disabled={page === 0}
           onClick={() => {
             swiperElRef.current.swiper.slidePrev();
           }}
@@ -38,7 +41,8 @@ function DetailSwiper({ content }) {
           <img src={left} alt="" width="40" height="40" draggable="false" />
         </button>
         <button
-          className={`${navigationClass} right-6 ${isLastPage ? "" : "lg:visible"}`}
+          className={`${navigationClass} right-6`}
+          disabled={isLastPage}
           onClick={() => {
             swiperElRef.current.swiper.slideNext();
           }}
@@ -53,11 +57,8 @@ function DetailSwiper({ content }) {
             <li
               className={i === page ? "text-black" : "text-neutral-300"}
               key={tabName}
-              onClick={() => {
-                swiperElRef.current.swiper.slideTo(i);
-              }}
             >
-              {tabName}
+              <button onClick={()=>swiperElRef.current.swiper.slideTo(i)}>{tabName}</button>
             </li>
           ))}
         </ul>

--- a/src/mainPage/features/detailInformation/DetailSwiper.jsx
+++ b/src/mainPage/features/detailInformation/DetailSwiper.jsx
@@ -54,11 +54,8 @@ function DetailSwiper({ content }) {
       <div className="w-full max-w-[1248px] px-12 lg:px-6 flex justify-end lg:justify-between align-center font-bold">
         <ul className="hidden lg:flex text-body-l gap-15 h-14 items-center">
           {content.map(({ tabName }, i) => (
-            <li
-              className={i === page ? "text-black" : "text-neutral-300"}
-              key={tabName}
-            >
-              <button onClick={()=>swiperElRef.current.swiper.slideTo(i)}>{tabName}</button>
+            <li className={i === page ? "text-black" : "text-neutral-300"} key={tabName}>
+              <button onClick={() => swiperElRef.current.swiper.slideTo(i)}>{tabName}</button>
             </li>
           ))}
         </ul>

--- a/src/mainPage/features/fcfs/cardGame/Card.jsx
+++ b/src/mainPage/features/fcfs/cardGame/Card.jsx
@@ -52,7 +52,13 @@ function Card({ index, locked, isFlipped, setFlipped, setGlobalLock, getCardAnsw
           className={`${cardFaceBaseStyle} ${style.back}`}
           src={answer1x}
           srcSet={`${answer1x} 1x, ${answer2x} 2x`}
-          alt={isFlipped ? (isCorrect ? "축하합니다, 당첨입니다!" : `${index}번 카드는 정답이 아니네요! 다른 카드를 뒤집으세요.`) : ""}
+          alt={
+            isFlipped
+              ? isCorrect
+                ? "축하합니다, 당첨입니다!"
+                : `${index}번 카드는 정답이 아니네요! 다른 카드를 뒤집으세요.`
+              : ""
+          }
           draggable="false"
           loading="lazy"
         />

--- a/src/mainPage/features/fcfs/cardGame/Card.jsx
+++ b/src/mainPage/features/fcfs/cardGame/Card.jsx
@@ -44,7 +44,7 @@ function Card({ index, locked, isFlipped, setFlipped, setGlobalLock, getCardAnsw
           className={`${cardFaceBaseStyle} ${style.front}`}
           src={hidden1x}
           srcSet={`${hidden1x} 1x, ${hidden2x} 2x`}
-          alt="hidden"
+          alt={isFlipped ? "" : `${index}번 카드를 뒤집으세요!`}
           draggable="false"
           loading="lazy"
         />
@@ -52,7 +52,7 @@ function Card({ index, locked, isFlipped, setFlipped, setGlobalLock, getCardAnsw
           className={`${cardFaceBaseStyle} ${style.back}`}
           src={answer1x}
           srcSet={`${answer1x} 1x, ${answer2x} 2x`}
-          alt={isCorrect ? "축하합니다, 당첨입니다!" : "아쉽게도 정답이 아니네요!"}
+          alt={isFlipped ? (isCorrect ? "축하합니다, 당첨입니다!" : `${index}번 카드는 정답이 아니네요! 다른 카드를 뒤집으세요.`) : ""}
           draggable="false"
           loading="lazy"
         />

--- a/src/mainPage/features/fcfs/cardGame/CardGame.jsx
+++ b/src/mainPage/features/fcfs/cardGame/CardGame.jsx
@@ -71,7 +71,9 @@ function CardGame({ offline }) {
           break;
         case submitCardgameErrorHandle[401]:
           return new Promise((resolve, reject) => {
-            openModal(<AuthModal onComplete={() => resolve(getCardAnswerOnline(index))} />).then( reject );
+            openModal(<AuthModal onComplete={() => resolve(getCardAnswerOnline(index))} />).then(
+              reject,
+            );
           });
         case submitCardgameErrorHandle["offline"]:
           setOfflineMode(true);

--- a/src/mainPage/features/fcfs/cardGame/CardGame.jsx
+++ b/src/mainPage/features/fcfs/cardGame/CardGame.jsx
@@ -70,8 +70,8 @@ function CardGame({ offline }) {
           openModal(<FcfsInvalidModal />);
           break;
         case submitCardgameErrorHandle[401]:
-          return new Promise((resolve) => {
-            openModal(<AuthModal onComplete={() => resolve(getCardAnswerOnline(index))} />);
+          return new Promise((resolve, reject) => {
+            openModal(<AuthModal onComplete={() => resolve(getCardAnswerOnline(index))} />).then( reject );
           });
         case submitCardgameErrorHandle["offline"]:
           setOfflineMode(true);

--- a/src/mainPage/features/fcfs/cardGame/index.jsx
+++ b/src/mainPage/features/fcfs/cardGame/index.jsx
@@ -13,10 +13,10 @@ function CardGameInitializer() {
 }
 
 function CardGamePariticipatedInitializer() {
-  const isLogin = useAuthStore((state) => state.isLogin);
-  const defferedLogin = useDeferredValue(isLogin);
+  const userId = useAuthStore((state) => state.userId);
+  const deferredUserId = useDeferredValue(userId);
   const getPariticipatedData = useFcfsStore((store) => store.getPariticipatedData);
-  getPariticipatedData(defferedLogin);
+  getPariticipatedData(deferredUserId);
   return null;
 }
 

--- a/src/mainPage/features/fcfs/modals/FcfsInvalidModal.jsx
+++ b/src/mainPage/features/fcfs/modals/FcfsInvalidModal.jsx
@@ -1,23 +1,20 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
 function FcfsInvalidModal() {
   const close = useContext(ModalCloseContext);
 
   return (
-    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[15.625rem] p-10 shadow bg-white relative flex flex-col justify-between items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <p className="text-body-l font-bold text-neutral-700">선착순 이벤트에 참여할 수 없습니다</p>
-        <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
-          아직 선착순 이벤트 진행 중이 아닙니다. 부적절한 방법으로 이벤트를 참여할 경우 향후
-          불이익이 가해질 수 있습니다.
-        </p>
-      </div>
+    <AlertModalContainer 
+      title="선착순 이벤트에 참여할 수 없습니다"
+      description="아직 선착순 이벤트 진행 중이 아닙니다. 부적절한 방법으로 이벤트를 참여할 경우 향후 불이익이 가해질 수 있습니다."
+    >
       <Button styleType="filled" onClick={close}>
         확인
       </Button>
-    </div>
+    </AlertModalContainer>
   );
 }
 

--- a/src/mainPage/features/fcfs/modals/FcfsInvalidModal.jsx
+++ b/src/mainPage/features/fcfs/modals/FcfsInvalidModal.jsx
@@ -7,7 +7,7 @@ function FcfsInvalidModal() {
   const close = useContext(ModalCloseContext);
 
   return (
-    <AlertModalContainer 
+    <AlertModalContainer
       title="선착순 이벤트에 참여할 수 없습니다"
       description="아직 선착순 이벤트 진행 중이 아닙니다. 부적절한 방법으로 이벤트를 참여할 경우 향후 불이익이 가해질 수 있습니다."
     >

--- a/src/mainPage/features/fcfs/modals/FcfsLoseModal.jsx
+++ b/src/mainPage/features/fcfs/modals/FcfsLoseModal.jsx
@@ -19,13 +19,15 @@ function FcfsLoseModal() {
     <AlertModalContainer
       title="이번 이벤트에 당첨되지 않았어요!"
       description=" 다음 이벤트 일정을 확인하세요!"
-      image={<img
-        src="/icons/lose@1x.png"
-        srcSet="/icons/lose@1x.png 1x, /icons/lose@2x.png 2x"
-        alt="선착순 이벤트 당첨 실패"
-        width="144"
-        height="146"
-      />}
+      image={
+        <img
+          src="/icons/lose@1x.png"
+          srcSet="/icons/lose@1x.png 1x, /icons/lose@2x.png 2x"
+          alt="선착순 이벤트 당첨 실패"
+          width="144"
+          height="146"
+        />
+      }
     >
       <div className="w-full flex flex-wrap justify-center gap-5">
         <Button styleType="filled" hidden={!shouldInteraction} onClick={toMoveInteraction}>

--- a/src/mainPage/features/fcfs/modals/FcfsLoseModal.jsx
+++ b/src/mainPage/features/fcfs/modals/FcfsLoseModal.jsx
@@ -1,5 +1,6 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 import scrollTo from "@main/scroll/scrollTo.js";
 import { INTERACTION_SECTION } from "@main/scroll/constants.js";
@@ -15,22 +16,17 @@ function FcfsLoseModal() {
   }
 
   return (
-    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[31.25rem] p-10 shadow bg-white relative flex flex-col justify-between items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <p className="text-body-l font-bold text-neutral-700">이번 이벤트에 당첨되지 않았어요!</p>
-        <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
-          다음 이벤트 일정을 확인하세요!
-        </p>
-      </div>
-      <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
-        <img
-          src="/icons/lose@1x.png"
-          srcSet="/icons/lose@1x.png 1x, /icons/lose@2x.png 2x"
-          alt="선착순 이벤트 당첨 실패"
-          width="144"
-          height="146"
-        />
-      </div>
+    <AlertModalContainer
+      title="이번 이벤트에 당첨되지 않았어요!"
+      description=" 다음 이벤트 일정을 확인하세요!"
+      image={<img
+        src="/icons/lose@1x.png"
+        srcSet="/icons/lose@1x.png 1x, /icons/lose@2x.png 2x"
+        alt="선착순 이벤트 당첨 실패"
+        width="144"
+        height="146"
+      />}
+    >
       <div className="w-full flex flex-wrap justify-center gap-5">
         <Button styleType="filled" hidden={!shouldInteraction} onClick={toMoveInteraction}>
           추첨 이벤트 참여하기
@@ -39,7 +35,7 @@ function FcfsLoseModal() {
           닫기
         </Button>
       </div>
-    </div>
+    </AlertModalContainer>
   );
 }
 

--- a/src/mainPage/features/fcfs/modals/FcfsWinModal.jsx
+++ b/src/mainPage/features/fcfs/modals/FcfsWinModal.jsx
@@ -1,32 +1,27 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
 function FcfsWinModal() {
   const close = useContext(ModalCloseContext);
 
   return (
-    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[31.25rem] p-10 shadow bg-white relative flex flex-col justify-between items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <p className="text-body-l font-bold text-neutral-700">선착순 이벤트에 당첨되었어요!</p>
-        <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
-          경품 수령은 입력하신 연락처로 개별 안내됩니다
-        </p>
-      </div>
-      <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
-        <img
+    <AlertModalContainer
+      title="선착순 이벤트에 당첨되었어요!"
+      description="경품 수령은 입력하신 연락처로 개별 안내됩니다"
+      image={<img
           src="/icons/win@1x.png"
           srcSet="/icons/win@1x.png 1x, /icons/win@2x.png 2x"
           alt="선착순 이벤트 당첨"
           width="320"
           height="320"
-        />
-      </div>
-      벤
+        />}
+    >
       <Button styleType="filled" onClick={close}>
         확인
       </Button>
-    </div>
+    </AlertModalContainer>
   );
 }
 

--- a/src/mainPage/features/fcfs/modals/FcfsWinModal.jsx
+++ b/src/mainPage/features/fcfs/modals/FcfsWinModal.jsx
@@ -10,13 +10,15 @@ function FcfsWinModal() {
     <AlertModalContainer
       title="선착순 이벤트에 당첨되었어요!"
       description="경품 수령은 입력하신 연락처로 개별 안내됩니다"
-      image={<img
+      image={
+        <img
           src="/icons/win@1x.png"
           srcSet="/icons/win@1x.png 1x, /icons/win@2x.png 2x"
           alt="선착순 이벤트 당첨"
           width="320"
           height="320"
-        />}
+        />
+      }
     >
       <Button styleType="filled" onClick={close}>
         확인

--- a/src/mainPage/features/header/AuthButtonSection.jsx
+++ b/src/mainPage/features/header/AuthButtonSection.jsx
@@ -17,9 +17,13 @@ function AuthButtonSection() {
   if (isLogin)
     return <button 
       onClick={()=>openModal(logoutModal)} 
-      className="text-body-s lg:text-body-m text-black"
+      aria-label="로그아웃하기"
+      className="text-body-s lg:text-body-m text-black overflow-hidden py-3 px-2 relative group/button"
     >
       {userName}님 환영합니다.
+      <div className="absolute top-0 left-0 w-full h-full bg-blue-400 text-white flex justify-center items-center translate-x-full transition-transform group-hover/button:translate-x-0 group-focus/button:translate-x-0">
+        로그아웃
+      </div>
     </button>;
 
   return (

--- a/src/mainPage/features/header/AuthButtonSection.jsx
+++ b/src/mainPage/features/header/AuthButtonSection.jsx
@@ -1,6 +1,7 @@
 import openModal from "@common/modal/openModal.js";
 import AuthModal from "@main/auth/AuthModal.jsx";
 import WelcomeModal from "@main/auth/Welcome";
+import LogoutModal from "@main/auth/Logout/LogoutConfirmModal.jsx";
 import useAuthStore from "@main/auth/store.js";
 
 function AuthButtonSection() {
@@ -11,9 +12,15 @@ function AuthButtonSection() {
   const authModal = (
     <AuthModal onComplete={(isFreshMember) => isFreshMember && openModal(welcomeModal)} />
   );
+  const logoutModal = <LogoutModal />;
 
   if (isLogin)
-    return <div className="text-body-s lg:text-body-m text-black">{userName}님 환영합니다.</div>;
+    return <button 
+      onClick={()=>openModal(logoutModal)} 
+      className="text-body-s lg:text-body-m text-black"
+    >
+      {userName}님 환영합니다.
+    </button>;
 
   return (
     <button

--- a/src/mainPage/features/header/Hamburger/Button.jsx
+++ b/src/mainPage/features/header/Hamburger/Button.jsx
@@ -5,6 +5,9 @@ function HamburgerButton({ children }) {
   const [opened, setOpened] = useState(false);
   return (
     <>
+      <div className="fixed -z-10 w-full top-0 left-0 bg-white flex md:hidden flex-col justify-center items-center gap-2">
+        <div className="w-full mt-16 shadow-xl">{opened && children}</div>
+      </div>
       <button
         className="flex md:hidden justify-center items-center size-6 z-10"
         aria-label="open-menu"
@@ -14,9 +17,6 @@ function HamburgerButton({ children }) {
           <div></div>
         </div>
       </button>
-      <div className="fixed -z-10 w-full top-0 left-0 bg-white flex md:hidden flex-col justify-center items-center gap-2">
-        <div className="w-full mt-16 shadow-xl">{opened && children}</div>
-      </div>
     </>
   );
 }

--- a/src/mainPage/features/header/index.jsx
+++ b/src/mainPage/features/header/index.jsx
@@ -28,23 +28,23 @@ export default function Header() {
     };
   }
 
+  const navItems = scrollSectionList.map((scrollSection, index) => (
+    <li
+      key={index}
+      className={`w-20 lg:w-24 h-ful cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
+    >
+      <button onClick={() => onClickScrollSection(index + 1)} className="flex justify-center items-center w-full h-full">{scrollSection}</button>
+    </li>
+  ))
+
   return (
     <nav className="sticky top-0 h-[60px] z-40 bg-white/[.36] backdrop-blur-xl flex justify-between px-6 lg:px-9 items-center font-bold select-none">
-      <span onClick={gotoTop} className="text-black text-body-l cursor-pointer">
+      <button onClick={gotoTop} className="text-black text-body-l cursor-pointer">
         The new IONIQ 5
-      </span>
+      </button>
 
       <ul className="hidden md:flex h-full gap-4 lg:gap-8 text-body-s lg:text-body-m relative">
-        {scrollSectionList.map((scrollSection, index) => (
-          <li
-            key={index}
-            onClick={() => onClickScrollSection(index + 1)}
-            className={`flex justify-center items-center w-20 lg:w-24 cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
-          >
-            {scrollSection}
-          </li>
-        ))}
-
+        {navItems}
         <div
           style={scrollDynamicStyle()}
           className={`w-20 lg:w-24 h-[3px] transition-transform ease-in-out-cubic duration-200 absolute bottom-0 left-0 ${currentSection > 0 ? style.moveBar : "hidden"}`}
@@ -56,15 +56,7 @@ export default function Header() {
       <HamburgerButton>
         <div className="w-full px-6 py-2 flex flex-col sm:flex-row gap-4 justify-between items-center">
           <ul className="flex flex-col sm:flex-row gap-4 lg:gap-8 text-body-s lg:text-body-m relative">
-            {scrollSectionList.map((scrollSection, index) => (
-              <li
-                key={index}
-                onClick={() => onClickScrollSection(index + 1)}
-                className={`flex justify-center items-center w-20 lg:w-24 cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
-              >
-                {scrollSection}
-              </li>
-            ))}
+            {navItems}
           </ul>
           <AuthButton />
         </div>

--- a/src/mainPage/features/header/index.jsx
+++ b/src/mainPage/features/header/index.jsx
@@ -1,6 +1,6 @@
 import scrollTo from "@main/scroll/scrollTo";
 import { useSectionStore } from "@main/scroll/store";
-import AuthButtonSection from "./AuthButtonSection.jsx";
+import AuthButton from "@main/auth/AuthButton.jsx";
 import HamburgerButton from "./Hamburger/Button.jsx";
 
 import style from "./index.module.css";
@@ -51,7 +51,7 @@ export default function Header() {
         />
       </ul>
       <div className="hidden md:flex">
-        <AuthButtonSection />
+        <AuthButton />
       </div>
       <HamburgerButton>
         <div className="w-full px-6 py-2 flex flex-col sm:flex-row gap-4 justify-between items-center">
@@ -66,7 +66,7 @@ export default function Header() {
               </li>
             ))}
           </ul>
-          <AuthButtonSection />
+          <AuthButton />
         </div>
       </HamburgerButton>
     </nav>

--- a/src/mainPage/features/header/index.jsx
+++ b/src/mainPage/features/header/index.jsx
@@ -33,9 +33,14 @@ export default function Header() {
       key={index}
       className={`w-20 lg:w-24 h-ful cursor-pointer ${currentSection - 1 === index ? "text-black" : "text-neutral-300"}`}
     >
-      <button onClick={() => onClickScrollSection(index + 1)} className="flex justify-center items-center w-full h-full">{scrollSection}</button>
+      <button
+        onClick={() => onClickScrollSection(index + 1)}
+        className="flex justify-center items-center w-full h-full"
+      >
+        {scrollSection}
+      </button>
     </li>
-  ))
+  ));
 
   return (
     <nav className="sticky top-0 h-[60px] z-40 bg-white/[.36] backdrop-blur-xl flex justify-between px-6 lg:px-9 items-center font-bold select-none">

--- a/src/mainPage/features/interactions/mock.js
+++ b/src/mainPage/features/interactions/mock.js
@@ -5,18 +5,19 @@ const eventParticipationDate = {
 };
 
 const handlers = [
-  http.get("/api/v1/event/draw/:eventId/participation", ({request}) =>{
+  http.get("/api/v1/event/draw/:eventId/participation", ({ request }) => {
     const token = request.headers.get("authorization");
-    if (token === null) return HttpResponse.json({dates: []});
+    if (token === null) return HttpResponse.json({ dates: [] });
 
     return HttpResponse.json(eventParticipationDate);
   }),
-  http.post("/api/v1/event/draw/:eventId/participation", ({request}) => {
+  http.post("/api/v1/event/draw/:eventId/participation", ({ request }) => {
     const token = request.headers.get("authorization");
     if (token === null) return HttpResponse.json(false, { status: 401 });
 
-    const dummyTodayStatus ="2024-09-10T12:00:00.000Z";
-    if(eventParticipationDate.dates.includes(dummyTodayStatus)) return HttpResponse.json(false, { status: 409 });
+    const dummyTodayStatus = "2024-09-10T12:00:00.000Z";
+    if (eventParticipationDate.dates.includes(dummyTodayStatus))
+      return HttpResponse.json(false, { status: 409 });
 
     eventParticipationDate.dates.push("2024-09-10T12:00:00.000Z");
     return HttpResponse.json(true);

--- a/src/mainPage/features/interactions/mock.js
+++ b/src/mainPage/features/interactions/mock.js
@@ -5,10 +5,22 @@ const eventParticipationDate = {
 };
 
 const handlers = [
-  http.get("/api/v1/event/draw/:eventId/participation", () =>
-    HttpResponse.json(eventParticipationDate),
-  ),
-  http.post("/api/v1/event/draw/:eventId/participation", () => HttpResponse.json(true)),
+  http.get("/api/v1/event/draw/:eventId/participation", ({request}) =>{
+    const token = request.headers.get("authorization");
+    if (token === null) return HttpResponse.json({dates: []});
+
+    return HttpResponse.json(eventParticipationDate);
+  }),
+  http.post("/api/v1/event/draw/:eventId/participation", ({request}) => {
+    const token = request.headers.get("authorization");
+    if (token === null) return HttpResponse.json(false, { status: 401 });
+
+    const dummyTodayStatus ="2024-09-10T12:00:00.000Z";
+    if(eventParticipationDate.dates.includes(dummyTodayStatus)) return HttpResponse.json(false, { status: 409 });
+
+    eventParticipationDate.dates.push("2024-09-10T12:00:00.000Z");
+    return HttpResponse.json(true);
+  }),
   http.post("/api/v1/url/shorten", () =>
     HttpResponse.json({
       shortUrl: "o1PiWwlZZU",

--- a/src/mainPage/features/interactions/modal/InteractionAnswer.jsx
+++ b/src/mainPage/features/interactions/modal/InteractionAnswer.jsx
@@ -20,7 +20,7 @@ function getParticipantState(index) {
   };
 }
 
-export default function InteractionAnswer({ isAnswerUp, setIsAnswerUp }) {
+export default function InteractionAnswer({ isAnswerUp, goBack }) {
   const index = useContext(InteractionContext);
 
   const isLogin = useAuthStore((state) => state.isLogin);
@@ -41,7 +41,7 @@ export default function InteractionAnswer({ isAnswerUp, setIsAnswerUp }) {
 
       <button
         tabIndex={isAnswerUp ? undefined : -1}
-        onClick={() => setIsAnswerUp(false)}
+        onClick={goBack}
         aria-label="뒤로가기"
         className="absolute top-5 xl:top-10 left-5 xl:left-10 p-1 xl:p-3 bg-neutral-800 rounded-full"
       >

--- a/src/mainPage/features/interactions/modal/InteractionAnswer.jsx
+++ b/src/mainPage/features/interactions/modal/InteractionAnswer.jsx
@@ -5,7 +5,7 @@ import ShareButton from "./buttons/ShareButton.jsx";
 import ParticipateButton from "./buttons/ParticipateButton.jsx";
 import AnswerDescription from "./AnswerDescription.jsx";
 
-import useUserStore from "@main/auth/store.js";
+import useAuthStore from "@main/auth/store.js";
 import useDrawEventStore from "@main/drawEvent/store.js";
 
 import style from "./InteractionAnswer.module.css";
@@ -14,10 +14,7 @@ import content from "../content.json";
 function getParticipantState(index) {
   return (state) => {
     if (!state.getOpenStatus(index) || state.fallbackMode) return "";
-    if (state.isTodayEvent(index)) {
-      if (state.currentJoined) return "오늘 응모가 완료되었습니다!";
-      else return "";
-    }
+    if (state.isTodayEvent(index) && state.currentJoined) return "오늘 응모가 완료되었습니다!";
     if (state.joinStatus[index]) return "이미 응모하셨습니다!";
     else return "응모 기간이 지났습니다!";
   };
@@ -26,7 +23,7 @@ function getParticipantState(index) {
 export default function InteractionAnswer({ isAnswerUp, setIsAnswerUp }) {
   const index = useContext(InteractionContext);
 
-  const isLogin = useUserStore((state) => state.isLogin);
+  const isLogin = useAuthStore((state) => state.isLogin);
   const isTodayEvent = useDrawEventStore((state) => state.isTodayEvent(index));
   const participantState = useDrawEventStore(getParticipantState(index));
   const [isAniPlaying, setIsAniPlaying] = useState(false);

--- a/src/mainPage/features/interactions/modal/InteractionModal.jsx
+++ b/src/mainPage/features/interactions/modal/InteractionModal.jsx
@@ -24,6 +24,7 @@ export default function InteractionModal() {
   const [isActive, setIsActive] = useState(false);
   const [isAnswerUp, setIsAnswerUp] = useState(false);
   const interactionRef = useRef(null);
+  const closeButtonRef = useRef(null);
 
   if (!InteractionComponent) return;
 
@@ -32,6 +33,7 @@ export default function InteractionModal() {
     <div className="w-[calc(100%-2rem)] h-[calc(100%-2rem)] md:size-5/6 relative bg-[url('/images/interactionBackdrop.webp')] bg-cover bg-center bg-black/80 border border-neutral-600 rounded overflow-hidden">
       <button
         onClick={close}
+        ref={closeButtonRef}
         className="z-10 absolute top-5 right-5 xl:top-10 xl:right-10 bg-neutral-800 p-1 xl:p-3 rounded-full select-none"
       >
         <img src="/icons/close-white.svg" alt="닫기" draggable="false" />
@@ -42,11 +44,14 @@ export default function InteractionModal() {
       </Suspense>
 
       <div className="absolute bottom-6 left-1/2 -translate-x-1/2 flex gap-4">
-        <ShowAnswerButton disabled={!isActive} onClick={() => setIsAnswerUp(true)} />
-        <ResetButton onClick={() => interactionRef.current.reset()} />
+        <ShowAnswerButton disabled={!isActive || isAnswerUp} onClick={() => setIsAnswerUp(true)} />
+        <ResetButton onClick={() => interactionRef.current.reset()} disabled={isAnswerUp} />
       </div>
 
-      <InteractionAnswer isAnswerUp={isAnswerUp} setIsAnswerUp={setIsAnswerUp} />
+      <InteractionAnswer isAnswerUp={isAnswerUp} goBack={()=>{
+        setIsAnswerUp(false);
+        closeButtonRef.current.focus();
+      }} />
     </div>
   );
 }

--- a/src/mainPage/features/interactions/modal/InteractionModal.jsx
+++ b/src/mainPage/features/interactions/modal/InteractionModal.jsx
@@ -48,10 +48,13 @@ export default function InteractionModal() {
         <ResetButton onClick={() => interactionRef.current.reset()} disabled={isAnswerUp} />
       </div>
 
-      <InteractionAnswer isAnswerUp={isAnswerUp} goBack={()=>{
-        setIsAnswerUp(false);
-        closeButtonRef.current.focus();
-      }} />
+      <InteractionAnswer
+        isAnswerUp={isAnswerUp}
+        goBack={() => {
+          setIsAnswerUp(false);
+          closeButtonRef.current.focus();
+        }}
+      />
     </div>
   );
 }

--- a/src/mainPage/features/interactions/modal/joinEvent.js
+++ b/src/mainPage/features/interactions/modal/joinEvent.js
@@ -2,18 +2,22 @@ import { isLogined } from "@main/auth/store.js";
 import drawEventStore from "@main/drawEvent/store.js";
 
 import { fetchServer } from "@common/dataFetch/fetchServer.js";
+import { mutate } from "@common/dataFetch/getQuery.js";
 import { EVENT_DRAW_ID } from "@common/constants.js";
 
 export default function joinEvent(index) {
   const isLogin = isLogined();
-  const { isTodayEvent, currentJoined, setCurrentJoin } = drawEventStore.getState();
+  const { isTodayEvent, getJoinStatus, setCurrentJoin } = drawEventStore.getState();
   const todayEvent = isTodayEvent(index);
 
-  if (!isLogin || !todayEvent || currentJoined) return;
+  if (!isLogin || !todayEvent || getJoinStatus(index) ) return;
 
-  fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`, { method: "post" })
-    .then(() => setCurrentJoin(true))
-    .catch(() => {
-      alert("이벤트 참여에 실패했습니다.");
-    });
+  mutate( 
+    "draw-info-data", 
+    ()=>fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`, { method: "post" }),
+    {
+      onSuccess: ()=>setCurrentJoin(true),
+      onError: ()=>alert("이벤트 참여에 실패했습니다.")
+    }
+  );
 }

--- a/src/mainPage/features/interactions/modal/joinEvent.js
+++ b/src/mainPage/features/interactions/modal/joinEvent.js
@@ -8,25 +8,28 @@ import { EVENT_DRAW_ID } from "@common/constants.js";
 const joinEventErrorHandler = {
   409: "이미 참여했습니다.",
   404: "이벤트가 존재하지 않습니다.",
-  offline: "오프라인 폴백 모드로 전환합니다."
-}
+  offline: "오프라인 폴백 모드로 전환합니다.",
+};
 
 export default function joinEvent(index) {
   const isLogin = isLogined();
-  const { isTodayEvent, getJoinStatus, setCurrentJoin, readjustJoinStatus, setFallbackMode } = drawEventStore.getState();
+  const { isTodayEvent, getJoinStatus, setCurrentJoin, readjustJoinStatus, setFallbackMode } =
+    drawEventStore.getState();
   const todayEvent = isTodayEvent(index);
 
-  if (!isLogin || !todayEvent || getJoinStatus(index) ) return;
+  if (!isLogin || !todayEvent || getJoinStatus(index)) return;
 
-  mutate( 
-    "draw-info-data", 
-    ()=>fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`, { method: "post" })
-      .catch(handleError(joinEventErrorHandler)),
+  mutate(
+    "draw-info-data",
+    () =>
+      fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`, { method: "post" }).catch(
+        handleError(joinEventErrorHandler),
+      ),
     {
-      onSuccess: ()=>setCurrentJoin(true),
-      onError: (e)=>{
-        switch(e.message) {
-          case joinEventErrorHandler[409]: 
+      onSuccess: () => setCurrentJoin(true),
+      onError: (e) => {
+        switch (e.message) {
+          case joinEventErrorHandler[409]:
             readjustJoinStatus();
             break;
           case joinEventErrorHandler[404]:
@@ -36,7 +39,7 @@ export default function joinEvent(index) {
           default:
             alert("이벤트 참여에 실패했습니다.");
         }
-      }
-    }
+      },
+    },
   );
 }

--- a/src/mainPage/features/interactions/modal/joinEvent.js
+++ b/src/mainPage/features/interactions/modal/joinEvent.js
@@ -1,23 +1,42 @@
 import { isLogined } from "@main/auth/store.js";
 import drawEventStore from "@main/drawEvent/store.js";
 
-import { fetchServer } from "@common/dataFetch/fetchServer.js";
+import { fetchServer, handleError } from "@common/dataFetch/fetchServer.js";
 import { mutate } from "@common/dataFetch/getQuery.js";
 import { EVENT_DRAW_ID } from "@common/constants.js";
 
+const joinEventErrorHandler = {
+  409: "이미 참여했습니다.",
+  404: "이벤트가 존재하지 않습니다.",
+  offline: "오프라인 폴백 모드로 전환합니다."
+}
+
 export default function joinEvent(index) {
   const isLogin = isLogined();
-  const { isTodayEvent, getJoinStatus, setCurrentJoin } = drawEventStore.getState();
+  const { isTodayEvent, getJoinStatus, setCurrentJoin, readjustJoinStatus, setFallbackMode } = drawEventStore.getState();
   const todayEvent = isTodayEvent(index);
 
   if (!isLogin || !todayEvent || getJoinStatus(index) ) return;
 
   mutate( 
     "draw-info-data", 
-    ()=>fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`, { method: "post" }),
+    ()=>fetchServer(`/api/v1/event/draw/${EVENT_DRAW_ID}/participation`, { method: "post" })
+      .catch(handleError(joinEventErrorHandler)),
     {
       onSuccess: ()=>setCurrentJoin(true),
-      onError: ()=>alert("이벤트 참여에 실패했습니다.")
+      onError: (e)=>{
+        switch(e.message) {
+          case joinEventErrorHandler[409]: 
+            readjustJoinStatus();
+            break;
+          case joinEventErrorHandler[404]:
+          case joinEventErrorHandler["offline"]:
+            setFallbackMode();
+            break;
+          default:
+            alert("이벤트 참여에 실패했습니다.");
+        }
+      }
     }
   );
 }

--- a/src/mainPage/features/interactions/subsidy/index.jsx
+++ b/src/mainPage/features/interactions/subsidy/index.jsx
@@ -52,7 +52,7 @@ function SubsidyInteraction({ interactCallback, $ref }) {
       />
       <div className="absolute z-0 w-96 h-96 top-[calc(50%-12rem)] flex justify-center items-center">
         <button
-          className="absolute size-[120px] active:scale-90 transition-transform"
+          className="absolute size-[120px] active:scale-90 rounded-full outline-yellow-400 transition-transform"
           aria-label="Space바를 눌러서 동전을 클릭하고, 예상 금액을 올려보세요!"
           onClick={onClick}
         >

--- a/src/mainPage/features/interactions/subsidy/index.jsx
+++ b/src/mainPage/features/interactions/subsidy/index.jsx
@@ -51,8 +51,9 @@ function SubsidyInteraction({ interactCallback, $ref }) {
         directive="동전을 클릭하여 예상 금액을 입력해보세요!"
       />
       <div className="absolute z-0 w-96 h-96 top-[calc(50%-12rem)] flex justify-center items-center">
-        <div
+        <button
           className="absolute size-[120px] active:scale-90 transition-transform"
+          aria-label="Space바를 눌러서 동전을 클릭하고, 예상 금액을 올려보세요!"
           onClick={onClick}
         >
           <div
@@ -68,7 +69,7 @@ function SubsidyInteraction({ interactCallback, $ref }) {
               draggable="false"
             />
           </div>
-        </div>
+        </button>
         <div className="absolute -z-10 w-full h-full">
           {[...lotties].map((id) => (
             <Lottie

--- a/src/mainPage/features/interactions/v2l/Puzzle.jsx
+++ b/src/mainPage/features/interactions/v2l/Puzzle.jsx
@@ -73,6 +73,7 @@ function Puzzle({ interactCallback, $ref }) {
               return newBoard;
             });
           };
+          const label = `퍼즐 조각 (${i%3}, ${Math.floor(i/3)}). ${shape.getLabel()}`;
 
           return (
             <PuzzlePiece
@@ -80,6 +81,7 @@ function Puzzle({ interactCallback, $ref }) {
               key={`puzzle-${i}`}
               onClick={onClick}
               fixRotate={fixRotate}
+              ariaLabel={label}
             />
           );
         })}

--- a/src/mainPage/features/interactions/v2l/Puzzle.jsx
+++ b/src/mainPage/features/interactions/v2l/Puzzle.jsx
@@ -73,7 +73,7 @@ function Puzzle({ interactCallback, $ref }) {
               return newBoard;
             });
           };
-          const label = `퍼즐 조각 (${i%3}, ${Math.floor(i/3)}). ${shape.getLabel()}`;
+          const label = `퍼즐 조각 (${i % 3}, ${Math.floor(i / 3)}). ${shape.getLabel()}`;
 
           return (
             <PuzzlePiece

--- a/src/mainPage/features/interactions/v2l/PuzzlePiece.jsx
+++ b/src/mainPage/features/interactions/v2l/PuzzlePiece.jsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
 import { LINEAR } from "./constants.js";
 
-function PuzzlePiece({ shape, onClick, fixRotate }) {
+function PuzzlePiece({ shape, onClick, fixRotate, ariaLabel }) {
   const [fixing, setFixing] = useState(false);
   const style = {
     transform: `rotate( ${shape.rotate * 90}deg)`,
   };
 
   return (
-    <div
+    <button
       style={style}
       className={`size-28 bg-black rounded-xl border-2 border-white transition-transform ease-out ${fixing ? "duration-0" : "duration-500"}`}
       onClick={() => {
@@ -21,6 +21,7 @@ function PuzzlePiece({ shape, onClick, fixRotate }) {
         fixRotate();
         setTimeout(() => setFixing(false), 60);
       }}
+      aria-label={ariaLabel}
     >
       <svg
         className="size-full stroke-blue-300 fill-transparent"
@@ -29,7 +30,7 @@ function PuzzlePiece({ shape, onClick, fixRotate }) {
       >
         <path d={shape.type === LINEAR ? "M 0 54 H 108" : "M108 54 H 54 V 108"} strokeWidth="8" />
       </svg>
-    </div>
+    </button>
   );
 }
 

--- a/src/mainPage/features/interactions/v2l/utils.js
+++ b/src/mainPage/features/interactions/v2l/utils.js
@@ -48,19 +48,21 @@ class PieceData {
     return newPiece;
   }
   getLabel() {
-    if(this.type === LINEAR) {
-      if(this.rotate % 2) return "위에서 아래로 이어짐.";
+    if (this.type === LINEAR) {
+      if (this.rotate % 2) return "위에서 아래로 이어짐.";
       else return "왼쪽에서 오른쪽으로 이어짐.";
-    }
-    else if(this.type === CURVED) {
-      switch(this.rotate % 4) {
-        case 0: return "오른쪽에서 아래로 이어짐.";
-        case 1: return "왼쪽에서 아래로 이어짐.";
-        case 2: return "왼쪽에서 위로 이어짐.";
-        case 3: return "오른쪽에서 위로 이어짐.";
+    } else if (this.type === CURVED) {
+      switch (this.rotate % 4) {
+        case 0:
+          return "오른쪽에서 아래로 이어짐.";
+        case 1:
+          return "왼쪽에서 아래로 이어짐.";
+        case 2:
+          return "왼쪽에서 위로 이어짐.";
+        case 3:
+          return "오른쪽에서 위로 이어짐.";
       }
-    }
-    else return "알 수 없는 모양."
+    } else return "알 수 없는 모양.";
   }
 }
 

--- a/src/mainPage/features/interactions/v2l/utils.js
+++ b/src/mainPage/features/interactions/v2l/utils.js
@@ -47,6 +47,21 @@ class PieceData {
     newPiece.rotate = this.rotate % 4;
     return newPiece;
   }
+  getLabel() {
+    if(this.type === LINEAR) {
+      if(this.rotate % 2) return "위에서 아래로 이어짐.";
+      else return "왼쪽에서 오른쪽으로 이어짐.";
+    }
+    else if(this.type === CURVED) {
+      switch(this.rotate % 4) {
+        case 0: return "오른쪽에서 아래로 이어짐.";
+        case 1: return "왼쪽에서 아래로 이어짐.";
+        case 2: return "왼쪽에서 위로 이어짐.";
+        case 3: return "오른쪽에서 위로 이어짐.";
+      }
+    }
+    else return "알 수 없는 모양."
+  }
 }
 
 export function generatePiece(shapeString) {

--- a/src/mainPage/features/qna/QnAArticle.jsx
+++ b/src/mainPage/features/qna/QnAArticle.jsx
@@ -24,7 +24,7 @@ function QnAArticle({ question, answer }) {
 
   return (
     <article className="w-full max-w-[1200px] flex flex-col gap-4 md:gap-6 lg:gap-8 py-2 md:py-4 lg:py-6 border-b border-neutral-200">
-      <div className="flex justify-between items-center cursor-pointer" onClick={onClick}>
+      <button className="flex justify-between items-center cursor-pointer" onClick={onClick}>
         <h3 className="flex gap-2 lg:gap-3 font-bold text-black text-body-m lg:text-body-l">
           <span className="text-blue-400">Q.</span>
           {question}
@@ -35,7 +35,7 @@ function QnAArticle({ question, answer }) {
           alt={opened ? "닫기" : "열기"}
           draggable="false"
         />
-      </div>
+      </button>
       <p
         className={`${staticArticleStyle} ${opened ? "before:scale-y-0" : "before:scale-y-100"} ${visible ? "block" : "hidden"}`}
       >

--- a/src/mainPage/shared/auth/AuthButton.jsx
+++ b/src/mainPage/shared/auth/AuthButton.jsx
@@ -8,25 +8,27 @@ import useDrawEventStore from "@main/drawEvent/store.js";
 function AuthButton() {
   const isLogin = useAuthStore((store) => store.isLogin);
   const userName = useAuthStore((store) => store.userName);
-  const setCurrentJoin = useDrawEventStore((store)=>store.setCurrentJoin);
+  const setCurrentJoin = useDrawEventStore((store) => store.setCurrentJoin);
 
   const welcomeModal = <WelcomeModal />;
   const authModal = (
     <AuthModal onComplete={(isFreshMember) => isFreshMember && openModal(welcomeModal)} />
   );
-  const logoutModal = <LogoutModal onLogout={()=>setCurrentJoin(false)} />;
+  const logoutModal = <LogoutModal onLogout={() => setCurrentJoin(false)} />;
 
   if (isLogin)
-    return <button 
-      onClick={()=>openModal(logoutModal)} 
-      aria-label="로그아웃하기"
-      className="text-body-s lg:text-body-m text-black overflow-hidden py-3 px-2 relative group/button"
-    >
-      {userName}님 환영합니다.
-      <div className="absolute top-0 left-0 w-full h-full bg-blue-400 text-white flex justify-center items-center translate-x-full transition-transform group-hover/button:translate-x-0 group-focus/button:translate-x-0">
-        로그아웃
-      </div>
-    </button>;
+    return (
+      <button
+        onClick={() => openModal(logoutModal)}
+        aria-label="로그아웃하기"
+        className="text-body-s lg:text-body-m text-black overflow-hidden py-3 px-2 relative group/button"
+      >
+        {userName}님 환영합니다.
+        <div className="absolute top-0 left-0 w-full h-full bg-blue-400 text-white flex justify-center items-center translate-x-full transition-transform group-hover/button:translate-x-0 group-focus/button:translate-x-0">
+          로그아웃
+        </div>
+      </button>
+    );
 
   return (
     <button

--- a/src/mainPage/shared/auth/AuthButton.jsx
+++ b/src/mainPage/shared/auth/AuthButton.jsx
@@ -1,18 +1,20 @@
 import openModal from "@common/modal/openModal.js";
-import AuthModal from "@main/auth/AuthModal.jsx";
-import WelcomeModal from "@main/auth/Welcome";
-import LogoutModal from "@main/auth/Logout/LogoutConfirmModal.jsx";
-import useAuthStore from "@main/auth/store.js";
+import AuthModal from "./AuthModal.jsx";
+import WelcomeModal from "./Welcome";
+import LogoutModal from "./Logout/LogoutConfirmModal.jsx";
+import useAuthStore from "./store.js";
+import useDrawEventStore from "@main/drawEvent/store.js";
 
-function AuthButtonSection() {
+function AuthButton() {
   const isLogin = useAuthStore((store) => store.isLogin);
   const userName = useAuthStore((store) => store.userName);
+  const setCurrentJoin = useDrawEventStore((store)=>store.setCurrentJoin);
 
   const welcomeModal = <WelcomeModal />;
   const authModal = (
     <AuthModal onComplete={(isFreshMember) => isFreshMember && openModal(welcomeModal)} />
   );
-  const logoutModal = <LogoutModal />;
+  const logoutModal = <LogoutModal onLogout={()=>setCurrentJoin(false)} />;
 
   if (isLogin)
     return <button 
@@ -36,4 +38,4 @@ function AuthButtonSection() {
   );
 }
 
-export default AuthButtonSection;
+export default AuthButton;

--- a/src/mainPage/shared/auth/Logout/LogoutAlertModal.jsx
+++ b/src/mainPage/shared/auth/Logout/LogoutAlertModal.jsx
@@ -3,17 +3,18 @@ import { ModalCloseContext } from "@common/modal/modal.jsx";
 import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
-function LogoutAlertModal()
-{
-	const close = useContext(ModalCloseContext);
+function LogoutAlertModal() {
+  const close = useContext(ModalCloseContext);
 
-	return <AlertModalContainer title="성공적으로 로그아웃되었습니다." description="다음에 또 오세요!">
-		<div className="w-full flex flex-wrap justify-center gap-5">
-			<Button styleType="ghost" onClick={close}>
-				닫기
-			</Button>
-		</div>
-	</AlertModalContainer>
+  return (
+    <AlertModalContainer title="성공적으로 로그아웃되었습니다." description="다음에 또 오세요!">
+      <div className="w-full flex flex-wrap justify-center gap-5">
+        <Button styleType="ghost" onClick={close}>
+          닫기
+        </Button>
+      </div>
+    </AlertModalContainer>
+  );
 }
 
 export default LogoutAlertModal;

--- a/src/mainPage/shared/auth/Logout/LogoutAlertModal.jsx
+++ b/src/mainPage/shared/auth/Logout/LogoutAlertModal.jsx
@@ -1,0 +1,24 @@
+import { useContext } from "react";
+import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
+import Button from "@common/components/Button.jsx";
+
+function LogoutAlertModal({onLogout})
+{
+	const close = useContext(ModalCloseContext);
+	function onClick()
+	{
+		onLogout?.();
+		close();
+	}
+
+	return <AlertModalContainer title="성공적으로 로그아웃되었습니다." description="다음에 또 오세요!">
+		<div className="w-full flex flex-wrap justify-center gap-5">
+			<Button styleType="ghost" onClick={onClick}>
+				닫기
+			</Button>
+		</div>
+	</AlertModalContainer>
+}
+
+export default LogoutAlertModal;

--- a/src/mainPage/shared/auth/Logout/LogoutAlertModal.jsx
+++ b/src/mainPage/shared/auth/Logout/LogoutAlertModal.jsx
@@ -3,18 +3,13 @@ import { ModalCloseContext } from "@common/modal/modal.jsx";
 import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
-function LogoutAlertModal({onLogout})
+function LogoutAlertModal()
 {
 	const close = useContext(ModalCloseContext);
-	function onClick()
-	{
-		onLogout?.();
-		close();
-	}
 
 	return <AlertModalContainer title="성공적으로 로그아웃되었습니다." description="다음에 또 오세요!">
 		<div className="w-full flex flex-wrap justify-center gap-5">
-			<Button styleType="ghost" onClick={onClick}>
+			<Button styleType="ghost" onClick={close}>
 				닫기
 			</Button>
 		</div>

--- a/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
+++ b/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
@@ -7,26 +7,26 @@ import Button from "@common/components/Button.jsx";
 import { logout } from "@main/auth/store.js";
 import LogoutAlertModal from "./LogoutAlertModal.jsx";
 
-function LogoutConfirmModal({onLogout})
-{
-	const close = useContext(ModalCloseContext);
-	function clickLogout()
-	{
-		logout();
-		onLogout?.();
-		openModal(<LogoutAlertModal />);
-	}
+function LogoutConfirmModal({ onLogout }) {
+  const close = useContext(ModalCloseContext);
+  function clickLogout() {
+    logout();
+    onLogout?.();
+    openModal(<LogoutAlertModal />);
+  }
 
-	return <AlertModalContainer title="정말로 로그아웃하시겠습니까?">
-		<div className="w-full flex flex-wrap justify-center gap-5">
-			<Button styleType="ghost" onClick={clickLogout}>
-				로그아웃
-			</Button>
-			<Button styleType="filled" onClick={close}>
-				닫기
-			</Button>
-		</div>
-	</AlertModalContainer>
+  return (
+    <AlertModalContainer title="정말로 로그아웃하시겠습니까?">
+      <div className="w-full flex flex-wrap justify-center gap-5">
+        <Button styleType="ghost" onClick={clickLogout}>
+          로그아웃
+        </Button>
+        <Button styleType="filled" onClick={close}>
+          닫기
+        </Button>
+      </div>
+    </AlertModalContainer>
+  );
 }
 
 export default LogoutConfirmModal;

--- a/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
+++ b/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
@@ -1,9 +1,11 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import openModal from "@common/modal/openModal.js";
 import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
 import { logout } from "@main/auth/store.js";
+import LogoutAlertModal from "./LogoutAlertModal.jsx";
 
 function LogoutConfirmModal({onLogout})
 {
@@ -11,6 +13,7 @@ function LogoutConfirmModal({onLogout})
 	function clickLogout()
 	{
 		logout();
+		openModal(<LogoutAlertModal />).then( ()=>onLogout?.() );
 	}
 
 	return <AlertModalContainer title="정말로 로그아웃하시겠습니까?">

--- a/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
+++ b/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
@@ -13,7 +13,8 @@ function LogoutConfirmModal({onLogout})
 	function clickLogout()
 	{
 		logout();
-		openModal(<LogoutAlertModal />).then( ()=>onLogout?.() );
+		onLogout?.();
+		openModal(<LogoutAlertModal />);
 	}
 
 	return <AlertModalContainer title="정말로 로그아웃하시겠습니까?">

--- a/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
+++ b/src/mainPage/shared/auth/Logout/LogoutConfirmModal.jsx
@@ -1,0 +1,28 @@
+import { useContext } from "react";
+import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
+import Button from "@common/components/Button.jsx";
+
+import { logout } from "@main/auth/store.js";
+
+function LogoutConfirmModal({onLogout})
+{
+	const close = useContext(ModalCloseContext);
+	function clickLogout()
+	{
+		logout();
+	}
+
+	return <AlertModalContainer title="정말로 로그아웃하시겠습니까?">
+		<div className="w-full flex flex-wrap justify-center gap-5">
+			<Button styleType="ghost" onClick={clickLogout}>
+				로그아웃
+			</Button>
+			<Button styleType="filled" onClick={close}>
+				닫기
+			</Button>
+		</div>
+	</AlertModalContainer>
+}
+
+export default LogoutConfirmModal;

--- a/src/mainPage/shared/auth/store.js
+++ b/src/mainPage/shared/auth/store.js
@@ -34,18 +34,18 @@ function createUserStore() {
   if (typeof window === "undefined") return defaultUserState;
   tokenSaver.init(SERVICE_TOKEN_ID);
   const token = tokenSaver.get(SERVICE_TOKEN_ID);
-  const userName = parseTokenToUserName(token);
-  if (token === null) return { isLogin: false, userName: "" };
-  else return { isLogin: true, userName };
+  const {userName, userId} = parseTokenAndGetData(token);
+  if (token === null) return { isLogin: false, userName: "", userId: "" };
+  else return { isLogin: true, userName, userId };
 }
 
-function parseTokenToUserName(token) {
+function parseTokenAndGetData(token) {
   if (token === null) return "";
   try {
-    const { userName } = jwtDecode(token);
-    return userName;
+    const { userName, userId } = jwtDecode(token);
+    return {userName, userId};
   } catch {
-    return "사용자";
+    return {userName: "사용자", userId: "1nvalidU5er"};
   }
 }
 
@@ -53,16 +53,16 @@ const userStore = new UserStore();
 
 export function login(token) {
   tokenSaver.set(token);
-  const userName = parseTokenToUserName(token);
-  userStore.setState(() => ({ isLogin: true, userName }));
+  const {userName, userId} = parseTokenAndGetData(token);
+  userStore.setState(() => ({ isLogin: true, userName, userId }));
 }
 
 export function logout() {
   tokenSaver.remove();
-  userStore.setState(() => ({ isLogin: false, userName: "" }));
+  userStore.setState(() => ({ isLogin: false, userName: "", userId: "" }));
 }
 
-function useUserStore(func, defaultValue = defaultUserState) {
+function useAuthStore(func, defaultValue = defaultUserState) {
   return useSyncExternalStore(
     userStore.subscribe.bind(userStore),
     () => userStore.getState(func),
@@ -74,4 +74,4 @@ export function isLogined() {
   return userStore.state.isLogin;
 }
 
-export default useUserStore;
+export default useAuthStore;

--- a/src/mainPage/shared/auth/store.js
+++ b/src/mainPage/shared/auth/store.js
@@ -34,7 +34,7 @@ function createUserStore() {
   if (typeof window === "undefined") return defaultUserState;
   tokenSaver.init(SERVICE_TOKEN_ID);
   const token = tokenSaver.get(SERVICE_TOKEN_ID);
-  const {userName, userId} = parseTokenAndGetData(token);
+  const { userName, userId } = parseTokenAndGetData(token);
   if (token === null) return { isLogin: false, userName: "", userId: "" };
   else return { isLogin: true, userName, userId };
 }
@@ -43,9 +43,9 @@ function parseTokenAndGetData(token) {
   if (token === null) return "";
   try {
     const { userName, userId } = jwtDecode(token);
-    return {userName, userId};
+    return { userName, userId };
   } catch {
-    return {userName: "사용자", userId: "1nvalidU5er"};
+    return { userName: "사용자", userId: "1nvalidU5er" };
   }
 }
 
@@ -53,7 +53,7 @@ const userStore = new UserStore();
 
 export function login(token) {
   tokenSaver.set(token);
-  const {userName, userId} = parseTokenAndGetData(token);
+  const { userName, userId } = parseTokenAndGetData(token);
   userStore.setState(() => ({ isLogin: true, userName, userId }));
 }
 

--- a/src/mainPage/shared/components/AlertModalContainer.jsx
+++ b/src/mainPage/shared/components/AlertModalContainer.jsx
@@ -1,0 +1,18 @@
+function AlertModalContainer({title, description, image, children})
+{
+	const containerStyle = "w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] p-10 shadow bg-white relative flex flex-col justify-between items-center"
+	return <div className={`${containerStyle} ${image == null ? "max-h-[15.625rem]" : "max-h-[31.25rem]" }`}>
+      <div className="flex flex-col gap-2 items-center">
+        <p className="text-body-l font-bold text-neutral-700">{title}</p>
+        <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
+          {description}
+        </p>
+      </div>
+      {image && <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
+        {image}
+      </div>}
+      {children}
+    </div>
+}
+
+export default AlertModalContainer;

--- a/src/mainPage/shared/components/AlertModalContainer.jsx
+++ b/src/mainPage/shared/components/AlertModalContainer.jsx
@@ -1,18 +1,24 @@
-function AlertModalContainer({title, description, image, children})
-{
-	const containerStyle = "w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] p-10 shadow bg-white relative flex flex-col justify-between items-center"
-	return <div className={`${containerStyle} ${image == null ? "max-h-[15.625rem]" : "max-h-[31.25rem]" }`}>
+function AlertModalContainer({ title, description, image, children }) {
+  const containerStyle =
+    "w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] p-10 shadow bg-white relative flex flex-col justify-between items-center";
+  return (
+    <div
+      className={`${containerStyle} ${image == null ? "max-h-[15.625rem]" : "max-h-[31.25rem]"}`}
+    >
       <div className="flex flex-col gap-2 items-center">
         <p className="text-body-l font-bold text-neutral-700">{title}</p>
         <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
           {description}
         </p>
       </div>
-      {image && <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
-        {image}
-      </div>}
+      {image && (
+        <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
+          {image}
+        </div>
+      )}
       {children}
     </div>
+  );
 }
 
 export default AlertModalContainer;

--- a/src/mainPage/shared/components/NoServerModal.jsx
+++ b/src/mainPage/shared/components/NoServerModal.jsx
@@ -1,25 +1,21 @@
 import { useContext } from "react";
 import { ModalCloseContext } from "@common/modal/modal.jsx";
+import AlertModalContainer from "@main/components/AlertModalContainer.jsx";
 import Button from "@common/components/Button.jsx";
 
 function NoServerModal() {
   const close = useContext(ModalCloseContext);
 
   return (
-    <div className="w-[calc(100%-1rem)] max-w-[31.25rem] h-[calc(100svh-2rem)] max-h-[31.25rem] p-10 shadow bg-white relative flex flex-col justify-between items-center">
-      <div className="flex flex-col gap-2 items-center">
-        <p className="text-body-l font-bold text-neutral-700">서버가 닫혔어요!</p>
-        <p className="w-full max-w-80 text-body-s font-medium text-neutral-400 text-center">
-          괜찮아요. 저희는 서버가 닫혀도 일부 동작은 가능하니까요!
-        </p>
-      </div>
-      <div className="absolute top-0 left-0 w-full h-full flex justify-center items-center pointer-events-none">
-        <img src="/icons/error.svg" alt="서버 닫힘" width="160" height="160" />
-      </div>
+    <AlertModalContainer
+      title="서버가 닫혔어요!"
+      description="괜찮아요. 저희는 서버가 닫혀도 일부 동작은 가능하니까요!"
+      image={<img src="/icons/error.svg" alt="서버 닫힘" width="160" height="160" />}
+    >
       <Button styleType="ghost" onClick={close}>
         닫기
       </Button>
-    </div>
+    </AlertModalContainer>
   );
 }
 

--- a/src/mainPage/shared/components/ResetButton.jsx
+++ b/src/mainPage/shared/components/ResetButton.jsx
@@ -1,7 +1,7 @@
 import Button from "@common/components/Button.jsx";
 import RefreshIcon from "./refresh.svg?react";
 
-export default function ResetButton({ onClick }) {
+export default function ResetButton({ onClick, disabled }) {
   return (
     <Button
       onClick={onClick}
@@ -9,6 +9,7 @@ export default function ResetButton({ onClick }) {
       backdrop="dark"
       aria-label="refresh"
       className="p-1 xl:p-2"
+      disabled={disabled}
     >
       <RefreshIcon />
     </Button>

--- a/src/mainPage/shared/drawEvent/DrawEventFetcher.jsx
+++ b/src/mainPage/shared/drawEvent/DrawEventFetcher.jsx
@@ -1,10 +1,11 @@
-import useUserStore from "@main/auth/store.js";
+import useAuthStore from "@main/auth/store.js";
 import useDrawStore from "./store.js";
 
 function InteractionEventJoinDataFetcher() {
-  const isLogin = useUserStore((store) => store.isLogin);
+  const userId = useAuthStore((store) => store.userId);
   const getData = useDrawStore((store) => store.getJoinData);
-  getData(isLogin);
+
+  getData(userId);
   return null;
 }
 

--- a/src/mainPage/shared/drawEvent/store.js
+++ b/src/mainPage/shared/drawEvent/store.js
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { fetchServer } from "@common/dataFetch/fetchServer.js";
-import { getQuery } from "@common/dataFetch/getQuery.js";
-import use from "@common/dataFetch/use.js";
+import { getQuery, getQuerySuspense } from "@common/dataFetch/getQuery.js";
 import { getServerPresiseTime, getDayDifference } from "@common/utils.js";
 import { EVENT_DRAW_ID, EVENT_START_DATE, DAY_MILLISEC } from "@common/constants.js";
 
@@ -39,11 +38,12 @@ const drawEventStore = create((set, get) => ({
         }
       }
     }
-    const fetcher = getQuery(`draw-info-data@${userId}`, promiseFn).then( newValue=>{
-      set(newValue);
-      return newValue;
-    } );
-    return use( fetcher );
+    async function setter() {
+      const newState = await getQuery(`draw-info-data@${userId}`, promiseFn);
+      set(newState);
+      return newState;
+    }
+    return getQuerySuspense( "__zustand__draw-event-store-getData", setter, [userId, set] );
   },
   setCurrentJoin: (value) => {
     set({ currentJoined: value });

--- a/src/mainPage/shared/drawEvent/store.js
+++ b/src/mainPage/shared/drawEvent/store.js
@@ -27,15 +27,14 @@ const drawEventStore = create((set, get) => ({
           getQuery("server-time", getServerPresiseTime),
           getJoinDataEvent(),
         ]);
-        const currentDay = getDayDifference(EVENT_START_DATE, serverTime);
         return { joinStatus, openBaseDate: serverTime, fallbackMode: false };
-      } catch(e) {
+      } catch (e) {
         return {
           joinStatus: [false, false, false, false, false],
           openBaseDate: new Date("9999-12-31"),
           currentJoined: false,
           fallbackMode: true,
-        }
+        };
       }
     }
     async function setter() {
@@ -43,19 +42,19 @@ const drawEventStore = create((set, get) => ({
       set(newState);
       return newState;
     }
-    return getQuerySuspense( "__zustand__draw-event-store-getData", setter, [userId, set] );
+    return getQuerySuspense("__zustand__draw-event-store-getData", setter, [userId, set]);
   },
   setCurrentJoin: (value) => {
     set({ currentJoined: value });
   },
   readjustJoinStatus: (index) => {
-    set(({joinStatus})=>{ 
+    set(({ joinStatus }) => {
       const newJoinStatus = [...joinStatus];
-      newJoinStatus[index] = true
-      return {joinStatus: newJoinStatus};
+      newJoinStatus[index] = true;
+      return { joinStatus: newJoinStatus };
     });
   },
-  setFallbackMode: () =>{
+  setFallbackMode: () => {
     set({
       joinStatus: [false, false, false, false, false],
       openBaseDate: new Date("9999-12-31"),

--- a/src/mainPage/shared/drawEvent/store.js
+++ b/src/mainPage/shared/drawEvent/store.js
@@ -20,7 +20,7 @@ const drawEventStore = create((set, get) => ({
   openBaseDate: new Date("9999-12-31"),
   currentJoined: false,
   fallbackMode: false,
-  getJoinData: (logined) => {
+  getJoinData: (userId) => {
     async function promiseFn() {
       try {
         const [serverTime, joinStatus] = await Promise.all([
@@ -28,15 +28,10 @@ const drawEventStore = create((set, get) => ({
           getJoinDataEvent(),
         ]);
         const currentDay = getDayDifference(EVENT_START_DATE, serverTime);
-
-        let currentJoined = get().currentJoined;
-        if (!currentJoined && currentDay >= 0 && currentDay < joinStatus.length) {
-          currentJoined = joinStatus[currentDay];
-        }
-
-        set({ joinStatus, openBaseDate: serverTime, currentJoined, fallbackMode: false });
+        
+        set({ joinStatus, openBaseDate: serverTime, fallbackMode: false });
         return joinStatus;
-      } catch {
+      } catch(e) {
         set({
           joinStatus: [false, false, false, false, false],
           openBaseDate: new Date("9999-12-31"),
@@ -46,7 +41,7 @@ const drawEventStore = create((set, get) => ({
         return [false, false, false, false, false];
       }
     }
-    return getQuerySuspense(`draw-info-data@${logined}`, promiseFn, [set]);
+    return getQuerySuspense(`draw-info-data@${userId}`, promiseFn, [get, set]);
   },
   setCurrentJoin: (value) => {
     set({ currentJoined: value });

--- a/src/mainPage/shared/realtimeEvent/store.js
+++ b/src/mainPage/shared/realtimeEvent/store.js
@@ -74,7 +74,7 @@ const fcfsStore = create((set) => ({
       const newState = await getQuery("fcfs-info-data", promiseFn);
       set(newState);
       return newState;
-    }
+    };
     return getQuerySuspense("fcfs-info-data", setter, [set]);
   },
   getPariticipatedData: (userId) => {

--- a/src/mainPage/shared/realtimeEvent/store.js
+++ b/src/mainPage/shared/realtimeEvent/store.js
@@ -63,21 +63,27 @@ const fcfsStore = create((set) => ({
 
       // get countdown and syncronize state
       const countdown = Math.ceil((currentEventTime - currentServerTime) / 1000);
-      set({
+      return {
         currentServerTime,
         currentEventTime,
         countdown,
         eventStatus: eventInfo.eventStatus,
-      });
+      };
     };
-    return getQuerySuspense("fcfs-info-data", promiseFn, [set]);
+    const setter = async function () {
+      const newState = await getQuery("fcfs-info-data", promiseFn);
+      set(newState);
+      return newState;
+    }
+    return getQuerySuspense("fcfs-info-data", setter, [set]);
   },
   getPariticipatedData: (userId) => {
-    const promiseFn = async function () {
-      const participated = await getFcfsParticipated();
+    const setter = async function () {
+      const participated = await getQuery(`fcfs-participated-data@${userId}`, getFcfsParticipated);
       set({ isParticipated: participated });
+      return participated;
     };
-    return getQuerySuspense(`fcfs-participated-data@${userId}`, promiseFn, [set]);
+    return getQuerySuspense(`__zustand__fcfs-participated-getData`, setter, [set, userId]);
   },
   setEventStatus: (eventStatus) => set({ eventStatus }),
   handleCountdown: () =>

--- a/src/mainPage/shared/realtimeEvent/store.js
+++ b/src/mainPage/shared/realtimeEvent/store.js
@@ -72,12 +72,12 @@ const fcfsStore = create((set) => ({
     };
     return getQuerySuspense("fcfs-info-data", promiseFn, [set]);
   },
-  getPariticipatedData: (isLogin) => {
+  getPariticipatedData: (userId) => {
     const promiseFn = async function () {
       const participated = await getFcfsParticipated();
       set({ isParticipated: participated });
     };
-    return getQuerySuspense(`fcfs-participated-data@${isLogin}`, promiseFn, [set]);
+    return getQuerySuspense(`fcfs-participated-data@${userId}`, promiseFn, [set]);
   },
   setEventStatus: (eventStatus) => set({ eventStatus }),
   handleCountdown: () =>


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #103
- #117 
- #84 
- #78

# 📝 작업 내용

> 메인 페이지에 로그아웃 기능을 추가했습니다.

> 일부 접근성을 개선했습니다.
- **모달 바깥으로 포커스가 나가지 않도록 변경**했습니다.
- 모달이 띄워져 있는 상태에서 Esc 키를 누르면 모달이 모두 닫히도록 변경했습니다.
- 내비게이션 바, QnA는 이제 탭 키로 조작 가능합니다.
- 상세정보 섹션의 내비게이션 버튼은 이제 안 보이더라도 탭 키로 확인하고 조작할 수 있습니다.
- 기타 부적절했던 aria-label을 수정해서 스크린 리더가 약간 더 잘 읽을 수 있도록 수정했습니다.

> 기대평이 20개보다 적을 시 발생하는 레이아웃 오류를 수정했습니다.
- 이제 기대평이 0개면 기대평이 없다는 폴백 엘리먼트가 추가됩니다.
- 기대평이 적더라도 이젠 약간 자연스러워 보이도록 수정했습니다.

> 몇몇 버그를 수정했습니다.
- zustand 상태 기반 데이터 불러오는 메소드들이, 캐시가 만료되기 전에 2번 이상 호출되는 경우, 상태를 갱신하지 않던 오류를 수정했습니다.
  - 구체적으로는, 선착순 이벤트나 추첨 이벤트의 데이터를 가져올 때, 로그인과 로그아웃을 2번 이상 전환하면 로그인 되어 있던 상태가 그대로 유지되던 버그를 수정했습니다.
- 비로그인 사용자가 선착순 이벤트에 참여를 시도한 뒤, 정보등록 모달을 닫으면 영원히 카드를 뒤집을 수 없던 버그를 수정했습니다.
- 재접속한 당일 참가자가 인터랙션에 참여했을 때의 표기 오류를 수정했습니다.
- 서버가 404나 서버닫힘 에러 외 다른 걸 반환했을 때 최상단 카운터에 NaN이 뜨던 버그를 수정했습니다.

> 기타 리팩토링을 수행했습니다.
- 기대평, 선착순 이벤트 시 표시되는 모달을 공통 양식화했습니다. 