### PR TITLE
[fix] 잡다하게 수정

### DIFF
--- a/src/adminPage/features/comment/id/Comments.jsx
+++ b/src/adminPage/features/comment/id/Comments.jsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@common/dataFetch/getQuery.js";
 import { fetchServer } from "@common/dataFetch/fetchServer.js";
+import { formatDate } from "@common/utils.js";
 import Pagination from "@admin/components/Pagination";
 import { useState } from "react";
 
@@ -26,20 +27,6 @@ export default function Comments({
         }),
     [page, searchString],
   );
-
-  function getDate(createdAt) {
-    const yy = createdAt.slice(2, 4);
-    const mm = createdAt.slice(5, 7);
-    const dd = createdAt.slice(8, 10);
-    return `${yy}-${mm}-${dd}`;
-  }
-
-  function getTime(createdAt) {
-    const hh = createdAt.slice(11, 13);
-    const mm = createdAt.slice(14, 16);
-    const ss = createdAt.slice(17, 19);
-    return `${hh}:${mm}:${ss}`;
-  }
 
   function checkComment(id) {
     if (checkedComments.has(id)) {
@@ -69,9 +56,9 @@ export default function Comments({
           />
 
           <div className="place-self-center flex items-center gap-1 text-body-s">
-            <span>{getDate(comment.createdAt)}</span>
+            <span>{formatDate(comment.createdAt, "YY-MM-DD")}</span>
 
-            <span className="text-neutral-500">{getTime(comment.createdAt)}</span>
+            <span className="text-neutral-500">{formatDate(comment.createdAt, "hh:mm:ss")}</span>
           </div>
 
           <span className="pr-4 overflow-hidden text-body-s text-ellipsis">{comment.content}</span>

--- a/src/adminPage/features/comment/index.jsx
+++ b/src/adminPage/features/comment/index.jsx
@@ -20,12 +20,17 @@ export default function AdminComment() {
   }
 
   function onChangeForm(e) {
-    const newString = e.target.value.replace(/[^0-9]/g, "");
-    const filteredFormString = formString.replace(/[^0-9]/g, "");
+    let newString = e.target.value.replace(/[^0-9]/g, "");
 
-    if (newString.length > 9) return;
+    if (!newString) {
+      newString = "";
+    } else if (newString.length <= 6) {
+      newString = "HD_" + newString;
+    } else if (newString.length <= 9) {
+      newString = "HD_" + newString.slice(0, 6) + "_" + newString.slice(6);
+    } else return;
 
-    if (newString !== filteredFormString) {
+    if (newString !== formString) {
       if (newString.length >= 6) {
         setSelectedEvent(-1);
         setIsSpread(true);
@@ -34,13 +39,7 @@ export default function AdminComment() {
         setIsSpread(false);
       }
     }
-    if (!newString) {
-      setFormString("");
-    } else if (newString.length <= 6) {
-      setFormString("HD_" + newString);
-    } else {
-      setFormString("HD_" + newString.slice(0, 6) + "_" + newString.slice(6));
-    }
+    setFormString(newString);
   }
 
   function searchEvent(e, eventId) {

--- a/src/adminPage/features/eventEdit/FcfsInput/FcfsItemInput.jsx
+++ b/src/adminPage/features/eventEdit/FcfsInput/FcfsItemInput.jsx
@@ -3,8 +3,9 @@ import { EventEditDispatchContext } from "../businessLogic/context.js";
 import { Input } from "@admin/components/SmallInput.jsx";
 import DateInput from "@admin/components/DateInput";
 import DeleteButton from "@admin/components/DeleteButton";
-import { formatDate, padNumber } from "@common/utils.js";
+import { formatDate, padNumber, getDayDifference } from "@common/utils.js";
 import fcfsInputGridStyle from "./tableStyle.js";
+import serverTimeStore from "@admin/serverTime/store.js";
 
 const MINUTE = 60;
 
@@ -34,9 +35,10 @@ function FcfsItemInput({ uniqueKey, date, start, end, participantCount, prizeInf
       ) : (
         <DateInput
           date={date}
-          setDate={(date) =>
-            dispatch({ type: "modify_fcfs_item", key: uniqueKey, value: { date } })
-          }
+          setDate={(date) => {
+            if (getDayDifference(serverTimeStore.getState().serverTime, date) <= 0) return;
+            dispatch({ type: "modify_fcfs_item", key: uniqueKey, value: { date } });
+          }}
           required
           size="4"
         />

--- a/src/mainPage/shared/auth/requestAuthCode.js
+++ b/src/mainPage/shared/auth/requestAuthCode.js
@@ -11,7 +11,7 @@ async function requestAuthCode(name, phoneNumber) {
   } catch (e) {
     return handleError({
       400: "잘못된 요청 형식입니다.",
-      409: "등록된 참여자 정보가 있습니다.",
+      409: "이미 등록된 전화번호가 존재합니다. 하단의 '이미 정보를 입력하신 적이 있으신가요?'를 클릭하세요.",
     })(e);
   }
 }

--- a/src/mainPage/shared/auth/requestAuthCode.js
+++ b/src/mainPage/shared/auth/requestAuthCode.js
@@ -1,9 +1,10 @@
 import { fetchServer, handleError } from "@/common/dataFetch/fetchServer.js";
+import { EVENT_ID } from "@common/constants";
 
 async function requestAuthCode(name, phoneNumber) {
   try {
     const body = { name, phoneNumber: phoneNumber.replace(/\D+/g, "") };
-    await fetchServer("/api/v1/event-user/send-auth", {
+    await fetchServer(`/api/v1/event-user/send-auth/${EVENT_ID}`, {
       method: "post",
       body,
     });


### PR DESCRIPTION

# 📝 작업 내용

- 사용자 정보 등록 모달에서 이미 존재하는 전화번호로 인증을 시도할 때 나타나는 문구를 하단의 링크를 클릭하라고 수정
- 번호 인증 요청 API 인자 추가
> 백엔드의 요청대로 ```/api/v1/event-user/send-auth``` 뒤에 이벤트 프레임 ID를 붙입니다.
- 어드민 기대평 조회에서 사용자들이 작성한 기대평의 작성시간을 한국 현지시간에 맞게 표시
- 어드민 기대평 페이지에서 이벤트 검색할 때 포맷에 맞는 id의 이벤트들만 자동검색에 뜨게 함
> ```HD_012345_678``` 형식 이외의 포맷은 비정상적인 id라고 판단, 자동검색에서 무시됩니다.
- 어드민 선착순 이벤트 생성/수정 시 현재 날짜와 같거나 이미 지난 날짜의 이벤트로 생성/수정하는 것을 막음