### PR TITLE
[fix] 어드민 빌드 환경에서 /events/(id)를 새로고침하면 404 에러가 뜨는 버그 수정

### DIFF
--- a/packages/adminPage/build.js
+++ b/packages/adminPage/build.js
@@ -17,6 +17,7 @@ const buildUrl = [
   "events/[id]",
   "comments",
   "comments/[id]",
+  "users"
 ];
 
 async function copyFolder(src, dest) {

--- a/packages/adminPage/public/robots.txt
+++ b/packages/adminPage/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/packages/adminPage/vercel.json
+++ b/packages/adminPage/vercel.json
@@ -5,11 +5,15 @@
       "destination": "http://softeerorange.store/api/:path*"
     },
     {
-      "source": "/events/:path*",
+      "source": "/events/create",
+      "destination": "/events/create.html"
+    },
+    {
+      "source": "/events/:path(:path((?!create(\\.html)?$).*)",
       "destination": "/events/[id].html"
     },
     {
-      "source": "/comments/:path*",
+      "source": "/comments/(.*)",
       "destination": "/comments/[id].html"
     }
   ],

--- a/packages/adminPage/vercel.json
+++ b/packages/adminPage/vercel.json
@@ -6,15 +6,19 @@
     },
     {
       "source": "/events/create",
-      "destination": "/events/create.html"
+      "destination": "/events/create"
     },
     {
-      "source": "/events/:path(:path((?!create(\\.html)?$).*)",
-      "destination": "/events/[id].html"
+      "source": "/events/(.*)/edit",
+      "destination": "/events/create"
+    },
+    {
+      "source": "/events/(.*)",
+      "destination": "/events/[id]"
     },
     {
       "source": "/comments/(.*)",
-      "destination": "/comments/[id].html"
+      "destination": "/comments/[id]"
     }
   ],
   "cleanUrls": true


### PR DESCRIPTION
# #️⃣ 연관 이슈

없음

# 📝 작업 내용

> 어드민 빌드 환경에서 /events/(id)를 새로고침하면 404 에러가 뜨는 버그를 수정했습니다.
> 어드민 빌드 환경에서 /users를 새로고침하면 404 에러가 뜨는 버그를 수정했습니다.