### PR TITLE
[feat] 어드민 유저 검색 관련

### DIFF
--- a/packages/adminPage/src/App.jsx
+++ b/packages/adminPage/src/App.jsx
@@ -30,8 +30,8 @@ function App() {
           <Route exact path="/events/:eventId/edit" element={<EventsEditPage />} />
           <Route path="/events/:eventId" element={<EventsDetailPage />} />
           <Route path="/events" element={<EventsPage />} />
-          <Route path="/comments/:eventId" element={<CommentsIDPage />} />
           <Route path="/comments" element={<CommentsPage />} />
+          <Route path="/comments/:eventId" element={<CommentsIDPage />} />
           <Route path="/users" element={<UsersPage />} />
         </Route>
         <Route path="/login" element={<LoginPage />} />

--- a/packages/adminPage/src/features/users/Users.jsx
+++ b/packages/adminPage/src/features/users/Users.jsx
@@ -9,7 +9,9 @@ export default function Comments({ searchString, category }) {
   const data = useQuery(
     "admin-users",
     () =>
-      fetchServer(`/api/v1/admin/event-users?page=${page - 1}&search=${searchString}&size=15`)
+      fetchServer(
+        `/api/v1/admin/event-users?page=${page - 1}&search=${searchString}&field=${category}&size=15`,
+      )
         .then((res) => {
           console.log(category);
           return res;

--- a/packages/adminPage/src/features/users/Users.jsx
+++ b/packages/adminPage/src/features/users/Users.jsx
@@ -13,7 +13,6 @@ export default function Comments({ searchString, category }) {
         `/api/v1/admin/event-users?page=${page - 1}&search=${searchString}&field=${category}&size=15`,
       )
         .then((res) => {
-          console.log(category);
           return res;
         })
         .catch((e) => {

--- a/packages/adminPage/src/features/users/Users.jsx
+++ b/packages/adminPage/src/features/users/Users.jsx
@@ -3,14 +3,13 @@ import { fetchServer } from "@common/dataFetch/fetchServer.js";
 import Pagination from "@admin/components/Pagination";
 import { useState } from "react";
 
-export default function Comments({ searchString, category }) {
-  searchString;
+export default function Comments({ searchParams }) {
   const [page, setPage] = useState(1);
   const data = useQuery(
     "admin-users",
     () =>
       fetchServer(
-        `/api/v1/admin/event-users?page=${page - 1}&search=${searchString}&field=${category}&size=15`,
+        `/api/v1/admin/event-users?page=${page - 1}&search=${searchParams.get("search") ?? ""}&field=${searchParams.get("field") ?? "userName"}&size=15`,
       )
         .then((res) => {
           return res;
@@ -20,7 +19,7 @@ export default function Comments({ searchString, category }) {
           console.log(e);
           return { users: [] };
         }),
-    [page, searchString],
+    [page, searchParams],
   );
 
   return (

--- a/packages/adminPage/src/features/users/index.jsx
+++ b/packages/adminPage/src/features/users/index.jsx
@@ -6,7 +6,7 @@ import { useState } from "react";
 export default function AdminCommentID() {
   const [formString, setFormString] = useState("");
   const [searchString, setSearchString] = useState("");
-  const [category, setCategory] = useState("name");
+  const [category, setCategory] = useState("userName");
 
   function searchComment(e) {
     e.preventDefault();
@@ -37,7 +37,7 @@ export default function AdminCommentID() {
             onChange={(e) => setCategory(e.target.value)}
             className="bg-transparent text-neutral-600"
           >
-            <option value="name">성명</option>
+            <option value="userName">성명</option>
             <option value="phoneNumber">전화번호</option>
             <option value="frameId">FrameId</option>
           </select>

--- a/packages/adminPage/src/features/users/index.jsx
+++ b/packages/adminPage/src/features/users/index.jsx
@@ -2,15 +2,19 @@ import Suspense from "@common/components/Suspense";
 import Loading from "./Loading.jsx";
 import Users from "./Users.jsx";
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 export default function AdminCommentID() {
   const [formString, setFormString] = useState("");
   const [searchString, setSearchString] = useState("");
   const [category, setCategory] = useState("userName");
 
+  const [searchParams, setSearchParams] = useSearchParams();
+
   function searchComment(e) {
     e.preventDefault();
     setSearchString(formString);
+    setSearchParams({ search: formString, field: category });
   }
 
   return (
@@ -58,7 +62,7 @@ export default function AdminCommentID() {
       </div>
 
       <Suspense fallback={<Loading />}>
-        <Users searchString={searchString} category={category} />
+        <Users searchParams={searchParams} setSearchParams={setSearchParams} />
       </Suspense>
     </div>
   );


### PR DESCRIPTION

# 📝 작업 내용

- 어드민 유저 조회 페이지에서 이제 성명, 전화번호, 이벤트 frameId의 필드값으로도 검색이 가능합니다.
- 어드민 유저 조회 페이지에서 검색 쿼리(검색 문자열, 필드)를 주소로 띄워 뒤로가기로 이전 검색결과를 확인할 수 있도록 했습니다.