### PR TITLE
[fix] 어드민 기대평 검색에서 새 문자열 검색 시 페이지 1로 초기화

### DIFF
--- a/packages/adminPage/src/features/comment/id/Comments.jsx
+++ b/packages/adminPage/src/features/comment/id/Comments.jsx
@@ -2,7 +2,6 @@ import { useQuery } from "@common/dataFetch/getQuery.js";
 import { fetchServer } from "@common/dataFetch/fetchServer.js";
 import { formatDate } from "@common/utils.js";
 import Pagination from "@admin/components/Pagination";
-import { useState } from "react";
 
 export default function Comments({
   eventId,
@@ -10,8 +9,10 @@ export default function Comments({
   setCheckedComments,
   setAllId,
   searchString,
+  page,
+  setPage
 }) {
-  const [page, setPage] = useState(1);
+
   const data = useQuery(
     eventId,
     () =>

--- a/packages/adminPage/src/features/comment/id/index.jsx
+++ b/packages/adminPage/src/features/comment/id/index.jsx
@@ -9,6 +9,7 @@ export default function AdminCommentID({ eventId }) {
   const [formString, setFormString] = useState("");
   const [searchString, setSearchString] = useState("");
   const [allId, setAllId] = useState([]);
+  const [page, setPage] = useState(1);
 
   function selectAll() {
     if (allId.every((id) => checkedComments.has(id))) {
@@ -26,6 +27,7 @@ export default function AdminCommentID({ eventId }) {
 
   function searchComment(e) {
     e.preventDefault();
+    setPage(1);
     setSearchString(formString);
   }
 
@@ -78,6 +80,8 @@ export default function AdminCommentID({ eventId }) {
           setCheckedComments={setCheckedComments}
           setAllId={setAllId}
           searchString={searchString}
+          page={page}
+          setPage={setPage}
         />
       </Suspense>
     </div>


### PR DESCRIPTION
# #️⃣ 연관 이슈

- 어드민 기대평 검색에서 새 문자열 검색 시 페이지 1로 초기화
