### PR TITLE
[hotfix] http 500대 상태를 서버가 닫혔을 때로 간주하도록 수정

### DIFF
--- a/packages/common/src/dataFetch/fetchServer.js
+++ b/packages/common/src/dataFetch/fetchServer.js
@@ -48,7 +48,8 @@ function createFetchOptions(options = {}) {
 async function fetchServerBase(url, options = {}) {
   try {
     const response = await fetch(url, createFetchOptions(options));
-    if (response.status >= 400 && response.status <= 599) throw new HTTPError(response);
+    if (response.status >= 400 && response.status <= 499) throw new HTTPError(response);
+    if (response.status >= 500) throw new ServerCloseError();
     const text = await response.text();
     if (text === "") return null;
     return JSON.parse(text);


### PR DESCRIPTION
# 📝 작업 내용

- 현재 프로젝트가 종료되어 백엔드 서버가 닫힌 상태입니다.
- 실제 서버가 닫혔을 때 502 에러가 발생하므로, http 500대 상태를 서버가 닫혔을 때로 간주하도록 수정했습니다.