### PR TITLE
1.0.1.1 hotfix

### DIFF
--- a/packages/common/src/dataFetch/fetchServer.js
+++ b/packages/common/src/dataFetch/fetchServer.js
@@ -48,7 +48,8 @@ function createFetchOptions(options = {}) {
 async function fetchServerBase(url, options = {}) {
   try {
     const response = await fetch(url, createFetchOptions(options));
-    if (response.status >= 400 && response.status <= 599) throw new HTTPError(response);
+    if (response.status >= 400 && response.status <= 499) throw new HTTPError(response);
+    if (response.status >= 500) throw new ServerCloseError();
     const text = await response.text();
     if (text === "") return null;
     return JSON.parse(text);


### PR DESCRIPTION
# 📝 작업 내용

- 서버가 닫혔을 때 실제로 502 에러가 발생하는 것을 반영하여, 오프라인 오류 시 offline-error가 발생하도록 했습니다.
- 이에 따라, 서버가 닫혔어도 카드 게임을 할 수 있게 되었습니다.